### PR TITLE
Release v1.2.0 (2025‑04‑22) Advanced Settings

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,2 +1,3 @@
 - the files in the Folder References are just that. It is the source code of SillyTavern for which we are building an extension. And it is the original Guided Generations Quickreply set wich we try to emulate.
-- After each code change, increment the patch version (y in 0.x.y) in manifest.json; increment patch version (y) with each time we are at a point where we test a change. And increment the minor version (x) with each commit to github. Only Increments If we changed anything on any other file then the manifest.json. Never Increment for the manifest.json itself.
+- Before each commit to git, increment the patch version (y in z.x.y) in manifest.json; Only Increments If we changed anything on any other file then the manifest.json. Never Increment for the manifest.json itself.
+- in addition to analizing and editing files always give a short explanation of what you are doing before each step.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ See [`JSDoc.md`](./JSDoc.md) for code-level documentation.
 - [Features](#features)
 - [Installation](#installation)
 - [Usage](#usage)
+- [Settings](#settings)
 - [Troubleshooting](#troubleshooting)
 - [License](#license)
 - [Contributing](#contributing)
@@ -83,6 +84,41 @@ See [`JSDoc.md`](./JSDoc.md) for code-level documentation.
 - Hover tooltips and context menus provide guidance and quick access to advanced features.
 - See in-app settings for feature toggles and auto-guide configuration.
 - For full technical details, see [`JSDoc.md`](./JSDoc.md).
+
+---
+
+## ⚙️ Settings
+
+All extension settings are managed via SillyTavern’s Extension Settings panel:
+
+- **Auto-Trigger**: toggle automatic execution of:
+  - Thinking Guide
+  - State Guide
+  - Clothes Guide
+
+- **Buttons Visibility**: show or hide action buttons:
+  - 1st Person Impersonation (👤)
+  - 2nd Person Impersonation (👥)
+  - 3rd Person Impersonation (🗣️)
+  - Guided Response (🐕)
+  - Guided Swipe (👈)
+  - Persistent Guides Menu (📖)
+
+- **Injection Role**: select the role (`system`, `assistant`, or `user`) used when injecting instructions.
+
+- **Presets**: for each guide/tool (Clothes, State, Thinking, Situational, Rules, Custom, Corrections, Spellchecker, Edit Intros, Impersonation 1st/2nd/3rd), choose any SillyTavern preset. Before running a guide/tool, the extension will switch to that preset (and its configured API/model), execute the action, then restore your previous preset—allowing different models per guide.
+
+- **Prompt Overrides**: customize the raw prompt template for each guide/tool. Use `{{input}}` for your input text and other placeholders as supported. Overrides apply to:
+  - Clothes Guide Prompt
+  - State Guide Prompt
+  - Thinking Guide Prompt
+  - Situational Guide Prompt
+  - Rules Guide Prompt
+  - Corrections Prompt
+  - Spellchecker Prompt
+  - Impersonate 1st/2nd/3rd Person Prompts
+  - Guided Response Prompt
+  - Guided Swipe Prompt
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -61,6 +61,19 @@ const defaultSettings = {
     presetImpersonate1st: '',
     presetImpersonate2nd: '',
     presetImpersonate3rd: '',
+    // Guide prompt overrides
+    promptClothes: 'as=char [OOC: Answer me out of Character! Considering where we are currently in the story, write me a list entailing the clothes and look, what they are currently wearing of all participating characters, including {{user}}, that are present in the current scene. Don\'t mention people or clothing pieces no longer relevant to the ongoing scene.] ',
+    promptState: 'as=char [OOC: Answer me out of Character! Considering the last response, write me a list entailing what state and position of all participating characters, including {{user}}, that are present in the current scene. Don\'t describe their clothes or how they are dressed. Don\'t mention people no longer relevant to the ongoing scene.] ',
+    promptThinking: 'name={{char}} [Write what {{char}} and other characters in the current scene are currently thinking, pure thought only. Do not include the {{user}}\'s thoughts.] ',
+    promptSituational: '[Analyze the chat history and provide a concise summary of current location, present characters, relevant objects, and recent events. Keep factual and neutral. Format in clear paragraphs.] ',
+    promptRules: '[Create a list of explicit rules that {{char}} has learned and follows from the story and their character description. Only include rules explicitly established in chat history or character info. Format as a numbered list.] ',
+    promptCorrections: 'Without any intro or outro correct the grammar, punctuation, and improve the paragraph\'s flow of: {{input}}',
+    promptSpellchecker: 'Without any intro or outro correct the grammar, punctuation, and improve the paragraph\'s flow of: {{input}}',
+    promptImpersonate1st: 'Write in first Person perspective from {{user}}. {{input}}',
+    promptImpersonate2nd: 'Write in second Person perspective from {{user}}, using you/yours for {{user}}. {{input}}',
+    promptImpersonate3rd: 'Write in third Person perspective from {{user}} using third-person pronouns for {{user}}. {{input}}',
+    promptGuidedResponse: '[Take the following into special consideration for your next message: {{input}}]',
+    promptGuidedSwipe: '[Take the following into special consideration for your next message: {{input}}]',
 };
 
 /**
@@ -147,6 +160,14 @@ function updateSettingsUI() {
             }
         });
 
+        // Populate guide prompt override textareas
+        ['promptClothes','promptState','promptThinking','promptSituational','promptRules','promptCorrections','promptSpellchecker','promptImpersonate1st','promptImpersonate2nd','promptImpersonate3rd','promptGuidedResponse','promptGuidedSwipe'].forEach(key => {
+            const textarea = document.getElementById(`gg_${key}`);
+            if (textarea) {
+                textarea.value = extension_settings[extensionName][key] ?? defaultSettings[key] ?? '';
+            }
+        });
+
         console.log(`${extensionName}: Settings UI updated.`);
     } else {
         console.warn(`${extensionName}: Settings container #${settingsPanelId} not found during updateSettingsUI.`);
@@ -213,6 +234,8 @@ function handleSettingChange(event) {
     } else if (target.tagName === 'SELECT') { // Handle dropdowns
         settingValue = target.value;
     } else if (target.tagName === 'INPUT' && target.type === 'text') {
+        settingValue = target.value;
+    } else if (target.tagName === 'TEXTAREA') {
         settingValue = target.value;
     } else {
         console.warn(`${extensionName}: Unhandled setting type: ${target.type}`);

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ import { updateCharacter } from './scripts/persistentGuides/updateCharacter.js';
 import { getContext, loadExtensionSettings, extension_settings, renderExtensionTemplateAsync } from '../../../extensions.js'; 
 // Import Preset Manager
 import { getPresetManager } from '../../../../scripts/preset-manager.js';
+import { loadSettingsPanel } from './scripts/settingsPanel.js';
 
 // --- Shared State for Impersonation Input Recovery ---
 let previousImpersonateInput = ''; // Input before the last impersonation
@@ -47,8 +48,19 @@ const defaultSettings = {
     showImpersonate1stPerson: true, // Default on
     showImpersonate2ndPerson: false, // Default on
     showImpersonate3rdPerson: false, // Default off
-    useGGSytemPreset: true, // NEW SETTING: Default to using the preset
     injectionEndRole: 'system', // NEW SETTING: Default role for non-chat injections
+    presetClothes: 'GGSytemPrompt',
+    presetState: 'GGSytemPrompt',
+    presetThinking: 'GGSytemPrompt',
+    presetSituational: 'GGSytemPrompt',
+    presetRules: 'GGSytemPrompt',
+    presetCustom: 'GGSytemPrompt',
+    presetCorrections: 'GGSytemPrompt',
+    presetSpellchecker: 'GGSytemPrompt',
+    presetEditIntros: 'GGSytemPrompt',
+    presetImpersonate1st: '',
+    presetImpersonate2nd: '',
+    presetImpersonate3rd: '',
 };
 
 /**
@@ -124,6 +136,17 @@ function updateSettingsUI() {
             injectionRoleSelect.value = extension_settings[extensionName].injectionEndRole;
         }
 
+        // Populate preset text fields
+        ['presetClothes','presetState','presetThinking','presetSituational','presetRules',
+         'presetCustom','presetCorrections','presetSpellchecker','presetEditIntros',
+         'presetImpersonate1st','presetImpersonate2nd','presetImpersonate3rd'
+        ].forEach(key => {
+            const input = document.getElementById(`gg_${key}`);
+            if (input) {
+                input.value = extension_settings[extensionName][key] ?? defaultSettings[key] ?? '';
+            }
+        });
+
         console.log(`${extensionName}: Settings UI updated.`);
     } else {
         console.warn(`${extensionName}: Settings container #${settingsPanelId} not found during updateSettingsUI.`);
@@ -188,6 +211,8 @@ function handleSettingChange(event) {
     if (target.type === 'checkbox') {
         settingValue = target.checked;
     } else if (target.tagName === 'SELECT') { // Handle dropdowns
+        settingValue = target.value;
+    } else if (target.tagName === 'INPUT' && target.type === 'text') {
         settingValue = target.value;
     } else {
         console.warn(`${extensionName}: Unhandled setting type: ${target.type}`);
@@ -696,71 +721,10 @@ $(document).ready(function() {
     setTimeout(() => {
         console.log(`[${extensionName}] Delay finished, initiating settings panel load...`);
         loadSettingsPanel();
-    }, 1000); // Increased delay to 1000ms (1 second)
-
+    }, 1000);
     // Attempt to install the preset (can run relatively early)
     installPreset();
 });
 
-// --- Settings Panel Loading --- (Keep existing loadSettingsPanel async function)
-async function loadSettingsPanel() {
-    const containerId = `extension_settings_${extensionName}`; // Use ID based on the new extensionName
-    let container = document.getElementById(containerId);
-
-    // *** ADDED DEBUG LOG ***
-    const parentContainer = document.getElementById('extensions_settings');
-    console.log(`[${extensionName}] Checking parent container #extensions_settings:`, parentContainer ? 'Found' : 'NOT Found');
-
-    // Check if container exists, create if not (robustness)
-    if (!container) {
-        // Use a more reliable selector if possible, or wait longer?
-        // Let's assume #extensions_settings is the correct parent for now.
-        // const settingsArea = document.getElementById('extensions_settings'); 
-        // Use the parentContainer variable we just checked
-        if (parentContainer) { 
-            console.log(`[${extensionName}] Settings container #${containerId} not initially found. Ensuring it exists...`); 
-            container = document.createElement('div');
-            container.id = containerId;
-            parentContainer.appendChild(container); // Append to the found parent
-        } else {
-            // If the main area itself isn't found, log an error and stop.
-            console.error(`${extensionName}: Could not find main settings area (#extensions_settings) to create container.`);
-            return; // Stop if we can't create the container
-        }
-    } else {
-        console.log(`${extensionName}: Settings container #${containerId} found.`);
-        // Clear previous content if any (important for reloads)
-        container.innerHTML = ''; 
-    }
-
-    // Use renderExtensionTemplateAsync instead of manual $.get
-    try {
-        console.log(`${extensionName}: Rendering settings template using renderExtensionTemplateAsync...`);
-        // Use the new extensionName for the template path, assuming the folder was renamed
-        const settingsHtml = await renderExtensionTemplateAsync(`third-party/${extensionName}`, 'settings');
-        console.log(`${extensionName}: Settings template rendered successfully.`);
-        
-        // Append the fetched HTML to the container using jQuery
-        $(container).html(settingsHtml); // Use jQuery's .html()
-        
-        // Defer the rest of the logic slightly to allow DOM update
-        setTimeout(() => {
-            console.log(`${extensionName}: DOM updated, now loading settings and adding listeners...`);
-            // ***** Load settings HERE, right before updating UI *****
-            loadSettings(); // Ensure settings are loaded/initialized
-
-            // Update the UI elements to reflect loaded settings
-            updateSettingsUI(); 
-
-            // Add event listeners AFTER the HTML is loaded AND UI is updated
-            addSettingsEventListeners();
-            console.log(`${extensionName}: Settings panel actions complete.`);
-        }, 100); // Increase delay slightly to 100ms just in case
-
-    } catch (error) {
-        console.error(`${extensionName}: Error rendering settings template with renderExtensionTemplateAsync:`, error);
-        if (container) { // Check if container exists before modifying
-             container.innerHTML = '<p>Error: Could not render settings template. Check browser console (F12).</p>';
-        }
-    }
-}
+// Export settings helpers for settingsPanel.js import
+export { loadSettings, updateSettingsUI, addSettingsEventListeners };

--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,5 @@
     "css": "style.css",
     "author": "Samuel Eiras",
     "description": "Adds guided generation tools as a native extension.",
-    "version": "1.1.6"
+    "version": "1.2.0"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,5 @@
     "css": "style.css",
     "author": "Samuel Eiras",
     "description": "Adds guided generation tools as a native extension.",
-    "version": "1.1.5"
+    "version": "1.1.6"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,5 @@
     "css": "style.css",
     "author": "Samuel Eiras",
     "description": "Adds guided generation tools as a native extension.",
-    "version": "1.1.3"
+    "version": "1.1.5"
 }

--- a/scripts/guidedImpersonate.js
+++ b/scripts/guidedImpersonate.js
@@ -34,8 +34,12 @@ const guidedImpersonate = async () => {
         presetSwitchEnd = `/preset {{getvar::oldPreset}}|\n`;
     }
 
+    // Use user-defined impersonate prompt override
+    const promptTemplate = extension_settings[extensionName]?.promptImpersonate1st ?? '';
+    const filledPrompt = promptTemplate.replace('{{input}}', currentInputText);
+
     // Only the core impersonate command remains
-    const stscriptCommand = `/impersonate await=true Write in first Person perspective from {{user}}. {{input}} |`;
+    const stscriptCommand = `/impersonate await=true ${filledPrompt} |`;
     const fullScript = presetSwitchStart + stscriptCommand + presetSwitchEnd;
 
     if (typeof SillyTavern !== 'undefined' && typeof SillyTavern.getContext === 'function') {

--- a/scripts/guidedImpersonate2nd.js
+++ b/scripts/guidedImpersonate2nd.js
@@ -22,8 +22,12 @@ const guidedImpersonate2nd = async () => {
     // --- If not restoring, proceed with impersonation ---
     setPreviousImpersonateInput(currentInputText); // Use shared setter
 
+    // Use user-defined 2nd-person impersonate prompt override
+    const promptTemplate = extension_settings[extensionName]?.promptImpersonate2nd ?? '';
+    const filledPrompt = promptTemplate.replace('{{input}}', currentInputText);
+
     // Only the core impersonate command remains (specific 2nd person prompt)
-    const stscriptCommand = `/impersonate await=true Write in second Person perspective from {{user}}, using you/yours for {{user}}. {{input}} |`;
+    const stscriptCommand = `/impersonate await=true ${filledPrompt} |`;
     // Determine target preset from settings
     const presetKey = 'presetImpersonate2nd';
     const targetPreset = extension_settings[extensionName]?.[presetKey];

--- a/scripts/guidedImpersonate2nd.js
+++ b/scripts/guidedImpersonate2nd.js
@@ -1,7 +1,7 @@
-// scripts/guidedimpersonate2nd.js
-import { getContext } from '../../../../extensions.js';
+// scripts/guidedImpersonate2nd.js
+import { getContext, extension_settings } from '../../../../extensions.js';
 // Import shared state functions
-import { getPreviousImpersonateInput, setPreviousImpersonateInput, getLastImpersonateResult, setLastImpersonateResult } from '../index.js'; 
+import { extensionName, getPreviousImpersonateInput, setPreviousImpersonateInput, getLastImpersonateResult, setLastImpersonateResult } from '../index.js'; 
 
 const guidedImpersonate2nd = async () => {
     const textarea = document.getElementById('send_textarea');
@@ -24,11 +24,22 @@ const guidedImpersonate2nd = async () => {
 
     // Only the core impersonate command remains (specific 2nd person prompt)
     const stscriptCommand = `/impersonate await=true Write in second Person perspective from {{user}}, using you/yours for {{user}}. {{input}} |`;
+    // Determine target preset from settings
+    const presetKey = 'presetImpersonate2nd';
+    const targetPreset = extension_settings[extensionName]?.[presetKey];
+    console.log(`[GuidedGenerations] Using preset for 2nd-person impersonate: ${targetPreset || 'none'}`);
+    let presetSwitchStart = '';
+    let presetSwitchEnd = '';
+    if (targetPreset) {
+        presetSwitchStart = `/preset|\n/setvar key=oldPreset {{pipe}}|\n/preset ${targetPreset}|\n`;
+        presetSwitchEnd = `/preset {{getvar::oldPreset}}|\n`;
+    }
+    const fullScript = presetSwitchStart + stscriptCommand + presetSwitchEnd;
 
     try {
         const context = getContext(); 
         if (typeof context.executeSlashCommandsWithOptions === 'function') {
-            await context.executeSlashCommandsWithOptions(stscriptCommand);
+            await context.executeSlashCommandsWithOptions(fullScript);
             
             // After completion, read the new input and store it in shared state
             setLastImpersonateResult(textarea.value); // Use shared setter

--- a/scripts/guidedImpersonate3rd.js
+++ b/scripts/guidedImpersonate3rd.js
@@ -22,8 +22,12 @@ const guidedImpersonate3rd = async () => {
     // --- If not restoring, proceed with impersonation ---
     setPreviousImpersonateInput(currentInputText); // Use shared setter
 
+    // Use user-defined 3rd-person impersonate prompt override
+    const promptTemplate = extension_settings[extensionName]?.promptImpersonate3rd ?? '';
+    const filledPrompt = promptTemplate.replace('{{input}}', currentInputText);
+
     // Only the core impersonate command remains (specific 3rd person prompt)
-    const stscriptCommand = `/impersonate await=true Write in third Person perspective from {{user}} using third-person pronouns for {{user}}. {{input}} |`;
+    const stscriptCommand = `/impersonate await=true ${filledPrompt} |`;
 
     // Determine target preset from settings
     const presetKey = 'presetImpersonate3rd';

--- a/scripts/guidedImpersonate3rd.js
+++ b/scripts/guidedImpersonate3rd.js
@@ -1,7 +1,7 @@
-// scripts/guidedimpersonate3rd.js
-import { getContext } from '../../../../extensions.js';
+// scripts/guidedImpersonate3rd.js
+import { getContext, extension_settings } from '../../../../extensions.js';
 // Import shared state functions
-import { getPreviousImpersonateInput, setPreviousImpersonateInput, getLastImpersonateResult, setLastImpersonateResult } from '../index.js'; 
+import { extensionName, getPreviousImpersonateInput, setPreviousImpersonateInput, getLastImpersonateResult, setLastImpersonateResult } from '../index.js'; 
 
 const guidedImpersonate3rd = async () => {
     const textarea = document.getElementById('send_textarea');
@@ -25,10 +25,22 @@ const guidedImpersonate3rd = async () => {
     // Only the core impersonate command remains (specific 3rd person prompt)
     const stscriptCommand = `/impersonate await=true Write in third Person perspective from {{user}} using third-person pronouns for {{user}}. {{input}} |`;
 
+    // Determine target preset from settings
+    const presetKey = 'presetImpersonate3rd';
+    const targetPreset = extension_settings[extensionName]?.[presetKey];
+    console.log(`[GuidedGenerations] Using preset for 3rd-person impersonate: ${targetPreset || 'none'}`);
+    let presetSwitchStart = '';
+    let presetSwitchEnd = '';
+    if (targetPreset) {
+        presetSwitchStart = `/preset|\n/setvar key=oldPreset {{pipe}}|\n/preset ${targetPreset}|\n`;
+        presetSwitchEnd = `/preset {{getvar::oldPreset}}|\n`;
+    }
+    const fullScript = presetSwitchStart + stscriptCommand + presetSwitchEnd;
+
     try {
         const context = getContext(); 
         if (typeof context.executeSlashCommandsWithOptions === 'function') {
-            await context.executeSlashCommandsWithOptions(stscriptCommand);
+            await context.executeSlashCommandsWithOptions(fullScript);
             
             // After completion, read the new input and store it in shared state
             setLastImpersonateResult(textarea.value); // Use shared setter

--- a/scripts/guidedResponse.js
+++ b/scripts/guidedResponse.js
@@ -27,6 +27,10 @@ const guidedResponse = async () => {
 
     let stscriptCommand;
 
+    // Use user-defined guided response prompt override
+    const promptTemplate = extension_settings[extensionName]?.promptGuidedResponse ?? '';
+    const filledPrompt = promptTemplate.replace('{{input}}', originalInput);
+
     // Check if it's a group chat using the helper function
     if (isGroupChat()) {
         stscriptCommand = 
@@ -35,13 +39,13 @@ const guidedResponse = async () => {
 /setvar key=x {{pipe}} |
 /buttons labels=x "Select members {{group}}" |
 /setglobalvar key=selection {{pipe}} |
-/inject id=instruct position=chat ephemeral=true depth=0 role=${injectionRole} [Take the following into special consideration for your next message: ${originalInput}] |
+/inject id=instruct position=chat ephemeral=true depth=0 role=${injectionRole} ${filledPrompt} |
 /trigger await=true {{getglobalvar::selection}}|
 `;
     } else {
         stscriptCommand = 
             `// Single character logic|
-/inject id=instruct position=chat ephemeral=true depth=0 role=${injectionRole} [Take the following into special consideration for your next message: ${originalInput}]|
+/inject id=instruct position=chat ephemeral=true depth=0 role=${injectionRole} ${filledPrompt}|
 /trigger await=true|
 `;
     }

--- a/scripts/persistentGuides/clothesGuide.js
+++ b/scripts/persistentGuides/clothesGuide.js
@@ -2,87 +2,25 @@
  * @file Contains the logic for the Clothes option in the Persistent Guides menu.
  */
 import { extensionName } from '../../index.js'; // Import from two levels up
-import { getContext, extension_settings } from '../../../../../extensions.js'; 
+import { extension_settings } from '../../../../../extensions.js';
+import { runGuideScript } from './runGuide.js';
 
 /**
  * Executes the Clothes Guide script to create a detailed description of what each character is wearing.
  * This helps maintain visual consistency throughout the chat.
  * @param {boolean} isAuto - Whether this guide is being auto-triggered (true) or called directly from menu (false)
  */
-const clothesGuide = async (isAuto = false) => { // Make async
-    // --- Get Settings ---
-    const usePresetSwitching = extension_settings[extensionName]?.useGGSytemPreset ?? true; 
-    const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system'; // Get the role setting
-
-    // --- Build Preset Switching Script Parts Conditionally ---
-    let presetSwitchStart = '';
-    let presetSwitchEnd = '';
-
-    if (usePresetSwitching) {
-        console.log(`[${extensionName}] Clothes Guide: Preset switching ENABLED.`);
-        presetSwitchStart = `
-// Get the currently active preset|
-/preset|
-/setvar key=currentPreset {{pipe}} |
-
-// If current preset is already GGSytemPrompt, do NOT overwrite oldPreset|
-/if left={{getvar::currentPreset}} rule=neq right="GGSytemPrompt" {: 
-   // Store the current preset in oldPreset|
-   /setvar key=oldPreset {{getvar::currentPreset}} |
-   // Now switch to GGSytemPrompt|
-   /preset GGSytemPrompt |
-:}| 
-`; // Note the closing pipe
-        presetSwitchEnd = `
-// Switch back to the original preset if it was stored|
-/preset {{getvar::oldPreset}} |
-`; // Note the closing pipe
-    } else {
-        console.log(`[${extensionName}] Clothes Guide: Preset switching DISABLED.`);
-        presetSwitchStart = `// Preset switching disabled by setting|`;
-        presetSwitchEnd = `// Preset switching disabled by setting|`;
-    }
-
-    // --- Build Main Script --- 
-    let mainScriptLogic = `/listinjects return=object | 
-/let injections {{pipe}} | 
-/let x {{var::injections}} | 
-/var index=clothes x | 
-/let y {{pipe}} | 
-/var index=value y |
-/inject id=clothes position=chat depth=4 [Relevant Informations for portraying characters {{pipe}}] |
-
-// Generate Clothes Description|
-/gen as=char [OOC: Answer me out of Character! Considering where we are currently in the story, write me a list entailing the clothes and look, what they are currently wearing of all participating characters, including {{user}}, that are present in the current scene. Don't mention People or clothing pieces who are no longer relevant to the ongoing scene.]  |
-
-// Inject the generated description|
-/inject id=clothes position=chat depth=1 role=${injectionRole} [Relevant Informations for portraying characters {{pipe}}] |`;
-
-    // Conditionally add /listinjects
-    let listInjectsCommand = '';
-    if (!isAuto) {
-        console.log(`[${extensionName}] Running in manual mode, adding /listinjects command`);
-        listInjectsCommand = `
-/listinjects |`;
-    } else {
-        console.log(`[${extensionName}] Running in auto mode, NOT adding /listinjects command`);
-    }
-
-    // Combine all parts
-    const stscriptCommand = presetSwitchStart + mainScriptLogic + presetSwitchEnd + listInjectsCommand;
-
-    console.log(`[${extensionName}] Executing Clothes Guide stscript: ${isAuto ? 'auto mode' : 'manual mode'}`);
-
-    // Use the context executeSlashCommandsWithOptions method
-    try {
-        const context = getContext(); // Use imported function
-        // Send the combined script via context
-        await context.executeSlashCommandsWithOptions(stscriptCommand, { showOutput: false }); // Keep output hidden
-        console.log(`[${extensionName}] Clothes Guide stscript executed.`);
-    } catch (error) {
-        console.error(`[${extensionName}] Error executing Clothes Guide stscript: ${error}`);
-    }
-    return true;
+const clothesGuide = async (isAuto = false) => {
+    const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system';
+    const genCommandSuffix = `/gen as=char [OOC: Answer me out of Character! Considering where we are currently in the story, write me a list entailing the clothes and look, what they are currently wearing of all participating characters, including {{user}}, that are present in the current scene. Don't mention People or clothing pieces who are no longer relevant to the ongoing scene.] |`;
+    const finalCommand = `/inject id=clothes position=chat depth=1 role=${injectionRole} [Relevant Informations for portraying characters {{pipe}}] |`;
+    return await runGuideScript({
+        guideId: 'clothes',
+        genCommandSuffix,
+        finalCommand,
+        isAuto,
+        previousInjectionAction: 'move'
+    });
 };
 
 // Export the function for use in the main extension file

--- a/scripts/persistentGuides/clothesGuide.js
+++ b/scripts/persistentGuides/clothesGuide.js
@@ -12,10 +12,12 @@ import { runGuideScript } from './runGuide.js';
  */
 const clothesGuide = async (isAuto = false) => {
     const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system';
-    const genCommandSuffix = `/gen as=char [OOC: Answer me out of Character! Considering where we are currently in the story, write me a list entailing the clothes and look, what they are currently wearing of all participating characters, including {{user}}, that are present in the current scene. Don't mention People or clothing pieces who are no longer relevant to the ongoing scene.] |`;
+    const genAs = 'as=char';
+    const genCommandSuffix = `[OOC: Answer me out of Character! Considering where we are currently in the story, write me a list entailing the clothes and look, what they are currently wearing of all participating characters, including {{user}}, that are present in the current scene. Don't mention People or clothing pieces who are no longer relevant to the ongoing scene.] `;
     const finalCommand = `/inject id=clothes position=chat depth=1 role=${injectionRole} [Relevant Informations for portraying characters {{pipe}}] |`;
     return await runGuideScript({
         guideId: 'clothes',
+        genAs,
         genCommandSuffix,
         finalCommand,
         isAuto,

--- a/scripts/persistentGuides/flushGuides.js
+++ b/scripts/persistentGuides/flushGuides.js
@@ -92,7 +92,7 @@ const flushGuides = async () => { // Make function async
     // --- Step 3: Execute the second script ---
     try {
         console.log(`[GuidedGenerations] Executing flush logic script with labels: "${buttonLabels}"`);
-        console.log(`[GuidedGenerations] Full script: ${flushLogicScript}`);
+
         await context.executeSlashCommandsWithOptions(flushLogicScript, {
              showOutput: true, // Show the final output/buttons to the user
              handleExecutionErrors: true

--- a/scripts/persistentGuides/rulesGuide.js
+++ b/scripts/persistentGuides/rulesGuide.js
@@ -1,84 +1,26 @@
 /**
  * @file Contains the logic for the Rules Guide option in the Persistent Guides menu.
  */
-import { isGroupChat, extensionName } from '../../index.js'; // Import from two levels up
-import { getContext, extension_settings } from '../../../../../extensions.js'; 
+import { extensionName } from '../../index.js'; // Import from two levels up
+import { extension_settings } from '../../../../../extensions.js';
+import { runGuideScript } from './runGuide.js';
 
 /**
  * Executes the Rules Guide script to track the explicit rules that characters have learned.
  * This helps maintain consistency in character behavior based on established rules.
  */
-const rulesGuide = async () => { // Make async
-    // --- Get Settings ---
-    const usePresetSwitching = extension_settings[extensionName]?.useGGSytemPreset ?? true; 
-    const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system'; // Get the role setting
-    console.log(`[${extensionName}] Rules Guide: useGGSytemPreset=${usePresetSwitching}, injectionEndRole=${injectionRole}`);
-
-    // --- Build Preset Switching Script Parts Conditionally ---
-    let presetSwitchStart = '';
-    let presetSwitchEnd = '';
-
-    if (usePresetSwitching) {
-        console.log(`[${extensionName}] Rules Guide: Preset switching ENABLED.`);
-        presetSwitchStart = `
-// Get the currently active preset|
-/preset|
-/setvar key=currentPreset {{pipe}} |
-
-// If current preset is already GGSytemPrompt, do NOT overwrite oldPreset|
-/if left={{getvar::currentPreset}} rule=neq right="GGSytemPrompt" {: 
-   // Store the current preset in oldPreset|
-   /setvar key=oldPreset {{getvar::currentPreset}} |
-   // Now switch to GGSytemPrompt|
-   /preset GGSytemPrompt |
-:}| 
-`; // Note the closing pipe
-        presetSwitchEnd = `
-// Switch back to the original preset if it was stored|
-/preset {{getvar::oldPreset}} |
-`; // Note the closing pipe
-    } else {
-        console.log(`[${extensionName}] Rules Guide: Preset switching DISABLED.`);
-        presetSwitchStart = `// Preset switching disabled by setting|`;
-        presetSwitchEnd = `// Preset switching disabled by setting|`;
-    }
-
-    // --- Build Main Script --- 
-    let mainScriptLogic = `
-// Rules |
-/flushinject rule_guide |`;
-    
-    // Add different script sections based on whether it's a group chat |
-    if (await isGroupChat()) { // Await the async check
-        console.log(`[${extensionName}] Detected Group Chat for Rules Guide`);
-        mainScriptLogic += `
-/split {{group}} |
-/setvar key=x {{pipe}} |
-/buttons labels=x "Select members {{group}}" |
-/setglobalvar key=selection {{pipe}} |
-/gen [Create a list of explicit rules that {{getglobalvar::selection}} has learned and follows from the story and their character description. Only include rules that have been explicitly established in the chat history or character information. Format as a numbered list.]  |
-/inject id=rule_guide position=chat depth=0 role=${injectionRole} [{{getglobalvar::selection}}'s rules: {{pipe}}] |`;
-    } else {
-        console.log(`[${extensionName}] Detected Single Chat for Rules Guide`);
-        mainScriptLogic += `
-/gen [Create a list of explicit rules that {{char}} has learned and follows from the story and their character description. Only include rules that have been explicitly established in the chat history or character information. Format as a numbered list.] |
-/inject id=rule_guide position=chat depth=0 role=${injectionRole} [{{char}}'s rules: {{pipe}}] |
-/listinjects |`;
-    }
-    
-    // Combine all parts, including the original /listinjects
-    const stscriptCommand = presetSwitchStart + mainScriptLogic + presetSwitchEnd;
-
-    // Use the context executeSlashCommandsWithOptions method
-    try {
-        const context = getContext(); // Use imported function
-        // Send the combined script via context
-        await context.executeSlashCommandsWithOptions(stscriptCommand, { showOutput: false }); // Keep output hidden
-        console.log(`[${extensionName}] Rules Guide stscript executed.`);
-    } catch (error) {
-        console.error(`[${extensionName}] Error executing Rules Guide: ${error}`);
-    }
-    return true;
+const rulesGuide = async (isAuto = false) => {
+    const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system';
+    const genCommandSuffix = `/gen [Create a list of explicit rules that {{char}} has learned and follows from the story and their character description. Only include rules that have been explicitly established in the chat history or character information. Format as a numbered list.] |`;
+    const label = `Character's rules: {{pipe}}`;
+    const finalCommand = `/inject id=rules position=chat depth=0 role=${injectionRole} [${label}] |`;
+    return await runGuideScript({
+        guideId: 'rules',
+        genCommandSuffix,
+        finalCommand,
+        isAuto,
+        previousInjectionAction: 'flush'
+    });
 };
 
 // Export the function for use in the main extension file

--- a/scripts/persistentGuides/rulesGuide.js
+++ b/scripts/persistentGuides/rulesGuide.js
@@ -11,7 +11,7 @@ import { runGuideScript } from './runGuide.js';
  */
 const rulesGuide = async (isAuto = false) => {
     const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system';
-    const genCommandSuffix = `/gen [Create a list of explicit rules that {{char}} has learned and follows from the story and their character description. Only include rules that have been explicitly established in the chat history or character information. Format as a numbered list.] |`;
+    const genCommandSuffix = `[Create a list of explicit rules that {{char}} has learned and follows from the story and their character description. Only include rules that have been explicitly established in the chat history or character information. Format as a numbered list.] `;
     const label = `Character's rules: {{pipe}}`;
     const finalCommand = `/inject id=rules position=chat depth=0 role=${injectionRole} [${label}] |`;
     return await runGuideScript({

--- a/scripts/persistentGuides/runGuide.js
+++ b/scripts/persistentGuides/runGuide.js
@@ -5,6 +5,7 @@ import { extensionName } from '../../index.js';
  * Generic runner for Persistent Guides STScript commands.
  * @param {{
  *   guideId: string,
+ *   genAs?: string,
  *   genCommandSuffix?: string,
  *   finalCommand?: string,
  *   isAuto?: boolean,
@@ -12,7 +13,7 @@ import { extensionName } from '../../index.js';
  * }} options
  * @returns {Promise<string|null>} Returns pipe output or null on failure.
  */
-export async function runGuideScript({ guideId, genCommandSuffix = '', finalCommand = '', isAuto = false, previousInjectionAction = 'none' }) {
+export async function runGuideScript({ guideId, genAs = '', genCommandSuffix = '', finalCommand = '', isAuto = false, previousInjectionAction = 'none' }) {
     // Determine user-defined preset for this guide
     const presetKey = `preset${guideId.charAt(0).toUpperCase()}${guideId.slice(1)}`;
     const rawPreset = extension_settings[extensionName]?.[presetKey] ?? '';
@@ -52,13 +53,16 @@ export async function runGuideScript({ guideId, genCommandSuffix = '', finalComm
     }
 
     // Assemble STScript
+    const asClause = genAs ? `${genAs} ` : '';
+    // Generate guide content with optional as= clause
+    const genLine = `/gen ${asClause}${genCommandSuffix} |`;
     let script = `// Initial guide setup|
 ${initCmd}
 
 ${presetSwitchStart}
 
 // Generate guide content|
-${genCommandSuffix}
+${genLine}
 ${finalCommand}
 ${presetSwitchEnd}`;
 

--- a/scripts/persistentGuides/runGuide.js
+++ b/scripts/persistentGuides/runGuide.js
@@ -1,0 +1,91 @@
+import { getContext, extension_settings } from '../../../../../extensions.js';
+import { extensionName } from '../../index.js';
+
+/**
+ * Generic runner for Persistent Guides STScript commands.
+ * @param {{
+ *   guideId: string,
+ *   genCommandSuffix?: string,
+ *   finalCommand?: string,
+ *   isAuto?: boolean,
+ *   previousInjectionAction?: 'move' | 'flush' | 'none'
+ * }} options
+ * @returns {Promise<string|null>} Returns pipe output or null on failure.
+ */
+export async function runGuideScript({ guideId, genCommandSuffix = '', finalCommand = '', isAuto = false, previousInjectionAction = 'none' }) {
+    // Determine user-defined preset for this guide
+    const presetKey = `preset${guideId.charAt(0).toUpperCase()}${guideId.slice(1)}`;
+    const rawPreset = extension_settings[extensionName]?.[presetKey] ?? '';
+    const presetValue = rawPreset.trim();
+
+    // Build preset switch commands
+    let presetSwitchStart = '';
+    let presetSwitchEnd = '';
+    if (presetValue) {
+        presetSwitchStart = `
+ // Get current preset|
+ /preset|
+ /setvar key=currentPreset {{pipe}} |
+ /if left={{getvar::currentPreset}} rule=neq right="${presetValue}" {:
+    /setvar key=oldPreset {{getvar::currentPreset}} |
+    /preset ${presetValue} |
+ }| 
+`;
+        presetSwitchEnd = `
+ /preset {{getvar::oldPreset}} |
+`;
+    }
+
+    // Handle previous injection based on action
+    let initCmd = '';
+    if (previousInjectionAction === 'move') {
+        initCmd = `// Read existing injection|
+/listinjects return=object |
+/let injections {{pipe}} |
+/let x {{var::injections}} |
+/var index=${guideId} x |
+/let y {{pipe}} |
+/var index=value y |
+/inject id=${guideId} position=chat depth=4 [Relevant Informations for portraying characters {{pipe}}] |`;
+    } else if (previousInjectionAction === 'flush') {
+        initCmd = `/flushinject ${guideId} |`;
+    }
+
+    // Assemble STScript
+    let script = `// Initial guide setup|
+${initCmd}
+
+${presetSwitchStart}
+
+// Generate guide content|
+${genCommandSuffix}
+${finalCommand}
+${presetSwitchEnd}`;
+
+    if (!isAuto) {
+        script += '\n/listinjects |';
+    } else if (!script.trim().endsWith('|')) {
+        script += ' |';
+    }
+
+    // Execute STScript via SillyTavern context
+    const context = getContext();
+    if (context && typeof context.executeSlashCommandsWithOptions === 'function') {
+        try {
+            const result = await context.executeSlashCommandsWithOptions(script, {
+                showOutput: false,
+                handleExecutionErrors: true
+            });
+            if (result && result.pipe != null && result.pipe !== '') {
+                return result.pipe;
+            }
+            return null;
+        } catch (err) {
+            console.error(`${extensionName}: Error executing guide script for ${guideId}:`, err);
+            return null;
+        }
+    } else {
+        console.error(`${extensionName}: Context unavailable to execute guide script for ${guideId}.`);
+        return null;
+    }
+}

--- a/scripts/persistentGuides/situationalGuide.js
+++ b/scripts/persistentGuides/situationalGuide.js
@@ -2,45 +2,31 @@
  * @file Contains the logic for the Situational Guide option in the Persistent Guides menu.
  */
 import { isGroupChat } from '../../index.js'; // Import from two levels up
+import { runGuideScript } from './runGuide.js';
 
 /**
- * Executes the Situational Guide script to analyze the current context and extract relevant information.
- * This guide helps provide an overview of the current situation and environment for the characters.
+ * @param {boolean} isAuto - Whether this guide is auto-triggered (true) or manual (false)
+ * @returns {Promise<string|null>}
  */
-const situationalGuide = () => {
-    console.log('[GuidedGenerations] Situational Guide button clicked');
-
-    let stscriptCommand = `/setvar key=inp {{input}} |
-/flushvar focus | 
-/if left={{getvar::inp}} {:/buttons labels=["Yes","No"] "You have text in the Inputfield! Do you want to use it as a Focus for the Guide?:"| /if left={{pipe}} right=Yes /setvar key=focus Focus on {{getvar::inp}}. |:}|
-/flushinject situation |
-/gen [Analyze the chat history and provide a concise summary of: 
+const situationalGuide = async (isAuto = false) => {
+    const genCommandSuffix = `/setvar key=inp {{input}} |
+/flushvar focus |
+/if left={{getvar::inp}} {:/buttons labels=["Yes","No"] "You have text in the Inputfield! Do you want to use it as a Focus for the Guide?:"| /if left={{pipe}} right=Yes /setvar key=focus Focus on {{getvar::inp}}. |:}| |
+/gen [Analyze the chat history and provide a concise summary of:
 1. Current location and setting (indoors/outdoors, time of day, weather if relevant)
 2. Present characters and their current activities
 3. Relevant objects, items, or environmental details that could influence interactions
 4. Recent events or topics of conversation (last 10-20 messages)
 {{getvar::focus}}
-Keep the overview factual and neutral without speculation. Format in clear paragraphs.] |
-/inject id=situation position=chat depth=3 [Current Situation: {{pipe}}] |
-/listinjects |`;
-
-    console.log(`[GuidedGenerations] Executing Situational Guide stscript`);
-
-    // Use the context executeSlashCommandsWithOptions method
-    if (typeof SillyTavern !== 'undefined' && typeof SillyTavern.getContext === 'function') {
-        const context = SillyTavern.getContext();
-        try {
-            // Send the combined script via context
-            context.executeSlashCommandsWithOptions(stscriptCommand, { showOutput: false }); // Keep output hidden
-            console.log('[GuidedGenerations] Situational Guide stscript executed.');
-        } catch (error) {
-            console.error(`[GuidedGenerations] Error executing Situational Guide: ${error}`);
-        }
-    } else {
-        console.error('[GuidedGenerations] SillyTavern context is not available.');
-    }
-    return true;
+Keep the overview factual and neutral without speculation. Format in clear paragraphs.] |`;
+    const finalCommand = `/inject id=situation position=chat depth=3 [Current Situation: {{pipe}}] |`;
+    return await runGuideScript({
+        guideId: 'situational',
+        genCommandSuffix,
+        finalCommand,
+        isAuto,
+        previousInjectionAction: 'flush'
+    });
 };
 
-// Export the function for use in the main extension file
 export default situationalGuide;

--- a/scripts/persistentGuides/situationalGuide.js
+++ b/scripts/persistentGuides/situationalGuide.js
@@ -10,14 +10,11 @@ import { runGuideScript } from './runGuide.js';
  */
 const situationalGuide = async (isAuto = false) => {
     const genCommandSuffix = `/setvar key=inp {{input}} |
-/flushvar focus |
-/if left={{getvar::inp}} {:/buttons labels=["Yes","No"] "You have text in the Inputfield! Do you want to use it as a Focus for the Guide?:"| /if left={{pipe}} right=Yes /setvar key=focus Focus on {{getvar::inp}}. |:}| |
-/gen [Analyze the chat history and provide a concise summary of:
+[Analyze the chat history and provide a concise summary of:
 1. Current location and setting (indoors/outdoors, time of day, weather if relevant)
 2. Present characters and their current activities
 3. Relevant objects, items, or environmental details that could influence interactions
 4. Recent events or topics of conversation (last 10-20 messages)
-{{getvar::focus}}
 Keep the overview factual and neutral without speculation. Format in clear paragraphs.] |`;
     const finalCommand = `/inject id=situation position=chat depth=3 [Current Situation: {{pipe}}] |`;
     return await runGuideScript({

--- a/scripts/persistentGuides/stateGuide.js
+++ b/scripts/persistentGuides/stateGuide.js
@@ -17,14 +17,15 @@ import { runGuideScript } from './runGuide.js';
 const stateGuide = async (isAuto = false) => {
     const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system';
 
-    const genCommandSuffix = `/gen as=char [OOC: Answer me out of Character! Considering the last response, write me a list entailing what state and position of all participating characters, including {{user}}, that are present in the current scene. Don't describe their clothes or how they are dressed. Don't mention People who are no longer relevant to the ongoing scene.] |`;
+    const genAs = 'as=char';
+    const genCommandSuffix = `[OOC: Answer me out of Character! Considering the last response, write me a list entailing what state and position of all participating characters, including {{user}}, that are present in the current scene. Don't describe their clothes or how they are dressed. Don't mention People who are no longer relevant to the ongoing scene.] `;
 
     const finalCommand = `/inject id=state position=chat depth=1 role=${injectionRole} [Relevant Informations for portraying characters {{pipe}}] |`;
 
     return await runGuideScript({
         guideId: 'state',
+        genAs,
         genCommandSuffix,
-        finalCommand,
         isAuto,
         previousInjectionAction: 'move'
     });

--- a/scripts/persistentGuides/stateGuide.js
+++ b/scripts/persistentGuides/stateGuide.js
@@ -6,6 +6,7 @@
 // Adjust the path based on your actual file structure if needed
 import { getContext, extension_settings } from '../../../../../extensions.js'; 
 import { extensionName } from '../../index.js'; // Import extensionName from index.js
+import { runGuideScript } from './runGuide.js';
 
 /**
  * Executes the State Guide script to track the physical state and positions of characters.
@@ -14,108 +15,19 @@ import { extensionName } from '../../index.js'; // Import extensionName from ind
  * @returns {Promise<string|null>} The generated state info from the pipe, or null on error.
  */
 const stateGuide = async (isAuto = false) => {
-    // --- Get Settings ---
-    // Use optional chaining and nullish coalescing for safety
-    const usePresetSwitching = extension_settings[extensionName]?.useGGSytemPreset ?? true; 
-    const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system'; // Get the role setting
+    const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system';
 
-    // --- Build Preset Switching Script Parts Conditionally ---
-    let presetSwitchStart = '';
-    let presetSwitchEnd = '';
+    const genCommandSuffix = `/gen as=char [OOC: Answer me out of Character! Considering the last response, write me a list entailing what state and position of all participating characters, including {{user}}, that are present in the current scene. Don't describe their clothes or how they are dressed. Don't mention People who are no longer relevant to the ongoing scene.] |`;
 
-    if (usePresetSwitching) {
-        presetSwitchStart = `
-// Get the currently active preset|
-/preset|
-/setvar key=currentPreset {{pipe}} |
+    const finalCommand = `/inject id=state position=chat depth=1 role=${injectionRole} [Relevant Informations for portraying characters {{pipe}}] |`;
 
-// If current preset is already GGSytemPrompt, do NOT overwrite oldPreset|
-/if left={{getvar::currentPreset}} rule=neq right="GGSytemPrompt" {: 
-   // Store the current preset in oldPreset|
-   /setvar key=oldPreset {{getvar::currentPreset}} |
-   // Now switch to GGSytemPrompt|
-   /preset GGSytemPrompt |
-:}| 
-`; // Note the closing pipe on the last comment and if block
-        presetSwitchEnd = `
-// Switch back to the original preset if it was stored|
-/preset {{getvar::oldPreset}} |
-`; // Note the closing pipe
-    } else {
-        presetSwitchStart = `// Preset switching disabled by setting|`;
-        presetSwitchEnd = `// Preset switching disabled by setting|`;
-    }
-
-    // --- Build Main Script ---
-    let stscriptCommand = `// Initial guide setup|
-/listinjects return=object | 
-/let injections {{pipe}} | 
-/let x {{var::injections}} | 
-/var index=state x | 
-/let y {{pipe}} | 
-/var index=value y |
-/inject id=state position=chat depth=4 [Relevant Informations for portraying characters {{pipe}}] |
-
-${presetSwitchStart}
-
-// Generate the state description|
-/gen as=char [OOC: Answer me out of Character! Considering the last response, write me a list entailing what state and position of all participating characters, including {{user}}, that are present in the current scene. Don't describe their clothes or how they are dressed. Don't mention People who are no longer relevant to the ongoing scene.]  |
-
-// Inject the generated state|
-/inject id=state position=chat depth=1 role=${injectionRole} [Relevant Informations for portraying characters {{pipe}}] |
-
-${presetSwitchEnd}
-`; // Removed extra pipe at the end here, will be added below if needed
-
-    // Only include /listinjects if not auto-triggered
-    if (!isAuto) {
-        stscriptCommand += `
-/listinjects |`; // Add the command and the required pipe
-    } else {
-        // Ensure the script ends with a pipe if no listinjects is added
-        if (!stscriptCommand.trim().endsWith('|')) {
-             stscriptCommand += ' |'; 
-        }
-    }
-
-    // --- Execute Script ---
-    // Use the context executeSlashCommandsWithOptions method
-    // Get context within the function call
-    const context = getContext(); 
-    if (context && typeof context.executeSlashCommandsWithOptions === 'function') {
-        try {
-            // Send the combined script via context and await the result
-            const result = await context.executeSlashCommandsWithOptions(stscriptCommand, {
-                showOutput: false, // Keep output hidden
-                handleExecutionErrors: true // Allow capturing script errors
-            });
-
-            console.log('[GuidedGenerations] State Guide stscript executed. Full Result:', result);
-
-            // Check specifically for STScript execution errors
-            if (result && result.isError) {
-                console.error(`[GuidedGenerations] STScript execution failed: ${result.errorMessage}`, result);
-                return null; // Indicate failure
-            }
-
-            // Check the pipe for the result
-            if (result && result.pipe !== undefined && result.pipe !== null && result.pipe !== '') {
-                if (typeof window !== 'undefined') {
-                    window.ggLastStateGeneratedContent = result.pipe;
-                }
-                return result.pipe; // Return the content from pipe
-            } else {
-                console.warn('[GuidedGenerations] State Guide did not return a value in the pipe. Result:', result);
-                return null; // Indicate failure or no output
-            }
-        } catch (error) {
-            console.error(`[GuidedGenerations] JavaScript error executing State Guide script: ${error}`);
-            return null; // Indicate failure
-        }
-    } else {
-        console.error('[GuidedGenerations] SillyTavern context or executeSlashCommandsWithOptions is not available.');
-        return null; // Indicate failure
-    }
+    return await runGuideScript({
+        guideId: 'state',
+        genCommandSuffix,
+        finalCommand,
+        isAuto,
+        previousInjectionAction: 'move'
+    });
 };
 
 // Export the function for use in the main extension file

--- a/scripts/persistentGuides/thinkingGuide.js
+++ b/scripts/persistentGuides/thinkingGuide.js
@@ -29,7 +29,7 @@ const thinkingGuide = async (isAuto = false) => {
         }
         if (!selection) return null;
         // Phase 2: generate and inject thoughts for selected member
-        const genCommandSuffix2 = `/gen name=${selection} [Write what ${selection} is currently thinking, pure thought only.] |`;
+        const genCommandSuffix2 = `name=${selection} [Write what ${selection} is currently thinking, pure thought only.] `;
         const injectLabel2 = `${selection} is currently thinking: {{pipe}}`;
         const finalCommand2 = `/inject id=thinking position=chat depth=0 role=${injectionRole} [${injectLabel2}] |`;
         return await runGuideScript({
@@ -41,7 +41,7 @@ const thinkingGuide = async (isAuto = false) => {
         });
     } else {
         // Single chat: generate and inject directly
-        const genCommandSuffix = `/gen name={{char}} [Write what {{char}} and other characters in the current scene are currently thinking, pure thought only. Do not include the {{user}}'s thoughts.] |`;
+        const genCommandSuffix = `name={{char}} [Write what {{char}} and other characters in the current scene are currently thinking, pure thought only. Do not include the {{user}}'s thoughts.] `;
         const injectLabel = `{{char}} is currently thinking: {{pipe}}`;
         const finalCommand = `/inject id=thinking position=chat depth=0 role=${injectionRole} [${injectLabel}] |`;
         return await runGuideScript({

--- a/scripts/persistentGuides/thinkingGuide.js
+++ b/scripts/persistentGuides/thinkingGuide.js
@@ -2,90 +2,56 @@
  * @file Contains the logic for the Thinking option in the Persistent Guides menu.
  */
 import { isGroupChat, extensionName } from '../../index.js'; // Import from two levels up
-import { getContext, extension_settings } from '../../../../../extensions.js'; 
+import { getContext, extension_settings } from '../../../../../extensions.js';
+import { runGuideScript } from './runGuide.js';
 
 /**
  * Executes the Thinking Guide script to create an insight into what characters are thinking.
  * This helps authors understand character motivations and inner thoughts without changing the chat.
  * @param {boolean} isAuto - Whether this guide is being auto-triggered (true) or called directly from menu (false)
  */
-const thinkingGuide = async (isAuto = false) => { // Make async
-    // --- Get Settings ---
-    const usePresetSwitching = extension_settings[extensionName]?.useGGSytemPreset ?? true; 
-    const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system'; // Get the role setting
-
-    // --- Build Preset Switching Script Parts Conditionally ---
-    let presetSwitchStart = '';
-    let presetSwitchEnd = '';
-
-    if (usePresetSwitching) {
-        presetSwitchStart = `
-// Get the currently active preset|
-/preset|
-/setvar key=currentPreset {{pipe}} |
-
-// If current preset is already GGSytemPrompt, do NOT overwrite oldPreset|
-/if left={{getvar::currentPreset}} rule=neq right="GGSytemPrompt" {: 
-   // Store the current preset in oldPreset|
-   /setvar key=oldPreset {{getvar::currentPreset}} |
-   // Now switch to GGSytemPrompt|
-   /preset GGSytemPrompt |
-:}| 
-`; // Note the closing pipe
-        presetSwitchEnd = `
-// Switch back to the original preset if it was stored|
-/preset {{getvar::oldPreset}} |
-`; // Note the closing pipe
+const thinkingGuide = async (isAuto = false) => {
+    const injectionRole = extension_settings[extensionName]?.injectionEndRole ?? 'system';
+    if (await isGroupChat()) {
+        // Phase 1: select group member via direct STScript
+        const selectionScript = `/split {{group}} |
+        /setvar key=x {{pipe}} |
+        /buttons labels=x Select members {{group}} |
+        /setglobalvar key=selection {{pipe}} |`;
+        let selection;
+        try {
+            const context = getContext();
+            const result = await context.executeSlashCommandsWithOptions(selectionScript, { showOutput: false });
+            selection = result?.pipe?.trim();
+        } catch (err) {
+            console.error(`[${extensionName}] Error selecting group member:`, err);
+            return null;
+        }
+        if (!selection) return null;
+        // Phase 2: generate and inject thoughts for selected member
+        const genCommandSuffix2 = `/gen name=${selection} [Write what ${selection} is currently thinking, pure thought only.] |`;
+        const injectLabel2 = `${selection} is currently thinking: {{pipe}}`;
+        const finalCommand2 = `/inject id=thinking position=chat depth=0 role=${injectionRole} [${injectLabel2}] |`;
+        return await runGuideScript({
+            guideId: 'thinking',
+            genCommandSuffix: genCommandSuffix2,
+            finalCommand: finalCommand2,
+            isAuto,
+            previousInjectionAction: 'flush'
+        });
     } else {
-        presetSwitchStart = `// Preset switching disabled by setting|`;
-        presetSwitchEnd = `// Preset switching disabled by setting|`;
+        // Single chat: generate and inject directly
+        const genCommandSuffix = `/gen name={{char}} [Write what {{char}} and other characters in the current scene are currently thinking, pure thought only. Do not include the {{user}}'s thoughts.] |`;
+        const injectLabel = `{{char}} is currently thinking: {{pipe}}`;
+        const finalCommand = `/inject id=thinking position=chat depth=0 role=${injectionRole} [${injectLabel}] |`;
+        return await runGuideScript({
+            guideId: 'thinking',
+            genCommandSuffix,
+            finalCommand,
+            isAuto,
+            previousInjectionAction: 'flush'
+        });
     }
-
-    // --- Build Main Script --- 
-    let mainScriptLogic = `
-// Thinking |
-/flushinject thinking |`;
-    
-    // Add different script sections based on whether it's a group chat | 
-    if (await isGroupChat()) { // Await the async check
-        mainScriptLogic += `
-/split {{group}} |
-/setvar key=x {{pipe}} |
-/buttons labels=x Select members {{group}} |
-/setglobalvar key=selection {{pipe}} |
-/gen [Write what {{getglobalvar::selection}} is currently thinking, do not describe their actions or dialogue, only pure thought and only {{getglobalvar::selection}}'s thoughts.]  |
-/inject id=thinking position=chat depth=0 role=${injectionRole} [{{getglobalvar::selection}} is currently thinking: {{pipe}}] |
-`;
-    } else {
-        mainScriptLogic += `
-/gen name={{char}} [Write what {{char}} and other characters that are in the current scene are currently thinking; do not describe their actions or dialogue, only pure thought. Do not include the {{user}}'s thoughts in this.]  |
-/inject id=thinking position=chat depth=0 role=${injectionRole} [{{char}} is currently thinking: {{pipe}}] |
-`;
-    }
-
-    // Conditionally add /listinjects
-    let listInjectsCommand = '';
-    if (!isAuto) {
-        listInjectsCommand = `
-/listinjects |`;
-    }
-
-    // Combine all parts
-    const stscriptCommand = presetSwitchStart + mainScriptLogic + presetSwitchEnd + listInjectsCommand;
-
-    // Print the full command for debugging
-    console.log(`[${extensionName}] Thinking Guide final stscript (isAuto=${isAuto}):`);
-    console.log(stscriptCommand);
-
-    try {
-        const context = getContext(); // Use imported function
-        // Send the combined script via context
-        await context.executeSlashCommandsWithOptions(stscriptCommand, { showOutput: false }); // Keep output hidden
-        console.log(`[${extensionName}] Thinking Guide stscript executed.`);
-    } catch (error) {
-        console.error(`[${extensionName}] Error executing Thinking Guide stscript: ${error}`);
-    }
-    return true;
 };
 
 // Export the function for use in the main extension file

--- a/scripts/settingsPanel.js
+++ b/scripts/settingsPanel.js
@@ -1,0 +1,90 @@
+// scripts/settingsPanel.js
+
+import { extensionName, loadSettings, updateSettingsUI, addSettingsEventListeners } from '../index.js';
+import { renderExtensionTemplateAsync } from '../../../../extensions.js';
+
+/**
+ * Loads and renders the settings HTML for the extension.
+ */
+export async function loadSettingsPanel() {
+    const containerId = `extension_settings_${extensionName}`;
+    let container = document.getElementById(containerId);
+
+    const parentContainer = document.getElementById('extensions_settings');
+    console.log(`[${extensionName}] Checking parent container #extensions_settings:`, parentContainer ? 'Found' : 'NOT Found');
+
+    if (!container) {
+        if (parentContainer) {
+            console.log(`[${extensionName}] Settings container #${containerId} not initially found. Ensuring it exists...`);
+            container = document.createElement('div');
+            container.id = containerId;
+            parentContainer.appendChild(container);
+        } else {
+            console.error(`${extensionName}: Could not find main settings area (#extensions_settings) to create container.`);
+            return;
+        }
+    } else {
+        console.log(`${extensionName}: Settings container #${containerId} found.`);
+        container.innerHTML = '';
+    }
+
+    try {
+        console.log(`${extensionName}: Rendering settings template using renderExtensionTemplateAsync...`);
+        const settingsHtml = await renderExtensionTemplateAsync(`third-party/${extensionName}`, 'settings');
+        console.log(`${extensionName}: Settings template rendered successfully.`);
+        $(container).html(settingsHtml);
+
+        setTimeout(() => {
+            console.log(`${extensionName}: DOM updated, now loading settings and adding listeners...`);
+            loadSettings();
+            updateSettingsUI();
+            addSettingsEventListeners();
+
+            // Setup preset and clear buttons with native event handlers
+            const presetButtons = container.querySelectorAll('.gg-preset-button');
+            presetButtons.forEach(btn => {
+                // Insert clear button
+                const clearBtn = document.createElement('button');
+                clearBtn.type = 'button';
+                clearBtn.className = 'gg-clear-button';
+                clearBtn.setAttribute('data-target', btn.getAttribute('data-target'));
+                clearBtn.textContent = '✖';
+                clearBtn.style.marginLeft = '4px';
+                clearBtn.style.color = 'red';
+                btn.insertAdjacentElement('afterend', clearBtn);
+
+                // Preset fill click
+                btn.addEventListener('click', () => {
+                    const key = btn.getAttribute('data-target');
+                    const input = document.getElementById(`gg_${key}`);
+                    if (input) {
+                        input.value = 'GGSytemPrompt';
+                        input.dispatchEvent(new Event('change', { bubbles: true }));
+                    }
+                });
+
+                // Clear click
+                clearBtn.addEventListener('click', () => {
+                    const key = clearBtn.getAttribute('data-target');
+                    const input = document.getElementById(`gg_${key}`);
+                    if (input) {
+                        input.value = '';
+                        input.dispatchEvent(new Event('change', { bubbles: true }));
+                    }
+                });
+            });
+
+            // Set width on preset text inputs
+            container.querySelectorAll('.gg-setting-input[type="text"]').forEach(input => {
+                input.style.minWidth = '200px';
+            });
+
+            console.log(`[${extensionName}] Settings panel actions complete.`);
+        }, 100);
+    } catch (error) {
+        console.error(`[${extensionName}] Error rendering settings template:`, error);
+        if (container) {
+            container.innerHTML = '<p>Error: Could not render settings template. Check browser console (F12).</p>';
+        }
+    }
+}

--- a/scripts/tools/corrections.js
+++ b/scripts/tools/corrections.js
@@ -26,6 +26,10 @@ export default async function corrections() {
     setPreviousImpersonateInput(originalInput);
     console.log(`[GuidedGenerations][Corrections] Original input saved: "${originalInput}"`);
 
+    // Use user-defined corrections prompt override
+    const promptTemplate = extension_settings[extensionName]?.promptCorrections ?? '';
+    const filledPrompt = promptTemplate.replace('{{input}}', originalInput);
+
     // Determine target preset from settings
     const presetKey = 'presetCorrections';
     const targetPreset = extension_settings[extensionName]?.[presetKey];
@@ -56,9 +60,10 @@ export default async function corrections() {
     const stscriptPart1 = `
         ${presetSwitchStartScript}
 
-        // Inject assistant message to rework and instructions| |
+        // Inject assistant message to rework and instructions|
         /inject id=msgtorework position=chat ephemeral=true depth=0 role=assistant {{lastMessage}}|
-        /inject id=instruct position=chat ephemeral=true depth=0 [OOC: Do not continue the story do not wrote in character, instead write {{char}}'s last response again but change it to reflect the following: ${originalInput}. Don't make any other changes besides this.] |
+        // Inject instructions using user override prompt|
+        /inject id=instruct position=chat ephemeral=true depth=0 [${filledPrompt}]|
     `;
     
     try {

--- a/scripts/tools/spellchecker.js
+++ b/scripts/tools/spellchecker.js
@@ -47,12 +47,16 @@ export default async function spellchecker() {
 `;
     }
 
+    // Use user-defined spellchecker prompt override
+    const promptTemplate = extension_settings[extensionName]?.promptSpellchecker ?? '';
+    const filledPrompt = promptTemplate.replace('{{input}}', originalInput);
+
     // Execute the spellchecker workflow
     const stscript = `
         ${presetSwitchStart}
 
         // Generate correction using the current input|
-        /genraw Without any intro or outro correct the grammar, and punctuation, and improves the paragraph's flow of: {{input}} |
+        /genraw ${filledPrompt} |
         // Replace the input field with the generated correction|
         /setinput {{pipe}}|
 

--- a/settings.html
+++ b/settings.html
@@ -47,18 +47,6 @@
                     </div>
                 </div>
                 <hr>
-                <h4>Preset Usage</h4> <!-- New Heading for Preset Setting -->
-                <div class="setting_item"> <!-- Container for the setting -->
-                    <div style="display: flex; align-items: center; margin-bottom: 5px;"> <!-- Flex container for checkbox and label -->
-                        <input type="checkbox" id="gg_useGGSytemPreset" name="useGGSytemPreset" class="gg-setting-input"> <!-- Checkbox - ID matches JS -->
-                        <label for="gg_useGGSytemPreset" style="margin-left: 8px;">Use 'GGSytemPrompt' Preset</label> <!-- Label next to checkbox -->
-                    </div>
-                    <small class="setting_item_description"> <!-- Description below -->
-                        Enables using the specialized 'GGSytemPrompt' preset for certain guides/tools (State, Thinking, Rules, Clothes guides; Spellchecker, Corrections tools). <br>
-                        This preset can improve the quality and relevance of the generated output. However, disabling it might reduce the likelihood of triggering censorship on models with strict filters.
-                    </small>
-                </div>
-                <hr> <!-- Add a separator -->
                 <h4>Injection Settings</h4> <!-- New Heading -->
                 <div class="setting_item"> <!-- Container for the new setting -->
                     <label for="gg_injectionEndRole" style="margin-bottom: 5px; display: block;">Send Injections as:</label> <!-- Label for the dropdown -->
@@ -70,6 +58,93 @@
                     <small class="setting_item_description"> <!-- Description -->
                         Determines the role assigned to the end of injected content (like Describe State/Clothes) before generation. 'System' is often best for guidance, 'Assistant' continues the flow, 'User' can sometimes be useful depending on the model/prompt structure. Default: System.
                     </small>
+                </div>
+                <hr>
+                <h4>Preset Usage</h4>
+                <!-- Preset fields for each guide/tool -->
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetClothes" style="margin-left: 8px; min-width:150px;">Clothes Guide</label>
+                        <input type="text" id="gg_presetClothes" name="presetClothes" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetClothes" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetState" style="margin-left: 8px; min-width:150px;">State Guide</label>
+                        <input type="text" id="gg_presetState" name="presetState" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetState" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetThinking" style="margin-left: 8px; min-width:150px;">Thinking Guide</label>
+                        <input type="text" id="gg_presetThinking" name="presetThinking" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetThinking" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetSituational" style="margin-left: 8px; min-width:150px;">Situational Guide</label>
+                        <input type="text" id="gg_presetSituational" name="presetSituational" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetSituational" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetRules" style="margin-left: 8px; min-width:150px;">Rules Guide</label>
+                        <input type="text" id="gg_presetRules" name="presetRules" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetRules" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetCustom" style="margin-left: 8px; min-width:150px;">Custom Guide</label>
+                        <input type="text" id="gg_presetCustom" name="presetCustom" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetCustom" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetCorrections" style="margin-left: 8px; min-width:150px;">Corrections</label>
+                        <input type="text" id="gg_presetCorrections" name="presetCorrections" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetCorrections" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetSpellchecker" style="margin-left: 8px; min-width:150px;">Spellchecker</label>
+                        <input type="text" id="gg_presetSpellchecker" name="presetSpellchecker" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetSpellchecker" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetEditIntros" style="margin-left: 8px; min-width:150px;">Edit Intros</label>
+                        <input type="text" id="gg_presetEditIntros" name="presetEditIntros" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetEditIntros" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetImpersonate1st" style="margin-left: 8px; min-width:150px;">Impersonate 1st</label>
+                        <input type="text" id="gg_presetImpersonate1st" name="presetImpersonate1st" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetImpersonate1st" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetImpersonate2nd" style="margin-left: 8px; min-width:150px;">Impersonate 2nd</label>
+                        <input type="text" id="gg_presetImpersonate2nd" name="presetImpersonate2nd" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetImpersonate2nd" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
+                </div>
+                <div class="setting_item">
+                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <label for="gg_presetImpersonate3rd" style="margin-left: 8px; min-width:150px;">Impersonate 3rd</label>
+                        <input type="text" id="gg_presetImpersonate3rd" name="presetImpersonate3rd" class="gg-setting-input text_pole" style="flex:1; margin-left:8px;">
+                        <button type="button" class="gg-preset-button" data-target="presetImpersonate3rd" style="margin-left:8px;">GGSystemPrompt</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/settings.html
+++ b/settings.html
@@ -146,6 +146,70 @@
                         <button type="button" class="gg-preset-button" data-target="presetImpersonate3rd" style="margin-left:8px;">GGSystemPrompt</button>
                     </div>
                 </div>
+                <hr>
+                <h4>Guide Prompt Overrides</h4>
+                <!-- Textareas for overriding default guide prompts -->
+                <div class="setting_item">
+                    <label for="gg_promptClothes" style="margin-left: 8px; min-width:150px; display:block;">Clothes Guide Prompt</label>
+                    <textarea id="gg_promptClothes" name="promptClothes" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptClothes" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptState" style="margin-left: 8px; min-width:150px; display:block;">State Guide Prompt</label>
+                    <textarea id="gg_promptState" name="promptState" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptState" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptThinking" style="margin-left: 8px; min-width:150px; display:block;">Thinking Guide Prompt</label>
+                    <textarea id="gg_promptThinking" name="promptThinking" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptThinking" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptSituational" style="margin-left: 8px; min-width:150px; display:block;">Situational Guide Prompt</label>
+                    <textarea id="gg_promptSituational" name="promptSituational" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptSituational" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptRules" style="margin-left: 8px; min-width:150px; display:block;">Rules Guide Prompt</label>
+                    <textarea id="gg_promptRules" name="promptRules" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptRules" style="margin-top:4px;">Default</button>
+                </div>
+                <!-- Additional Prompt Override Textareas -->
+                <div class="setting_item">
+                    <label for="gg_promptCorrections" style="margin-left: 8px; min-width:150px; display:block;">Corrections Prompt</label>
+                    <textarea id="gg_promptCorrections" name="promptCorrections" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptCorrections" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptSpellchecker" style="margin-left: 8px; min-width:150px; display:block;">Spellchecker Prompt</label>
+                    <textarea id="gg_promptSpellchecker" name="promptSpellchecker" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptSpellchecker" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptImpersonate1st" style="margin-left: 8px; min-width:150px; display:block;">Impersonate 1st Person Prompt</label>
+                    <textarea id="gg_promptImpersonate1st" name="promptImpersonate1st" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptImpersonate1st" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptImpersonate2nd" style="margin-left: 8px; min-width:150px; display:block;">Impersonate 2nd Person Prompt</label>
+                    <textarea id="gg_promptImpersonate2nd" name="promptImpersonate2nd" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptImpersonate2nd" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptImpersonate3rd" style="margin-left: 8px; min-width:150px; display:block;">Impersonate 3rd Person Prompt</label>
+                    <textarea id="gg_promptImpersonate3rd" name="promptImpersonate3rd" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptImpersonate3rd" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptGuidedResponse" style="margin-left: 8px; min-width:150px; display:block;">Guided Response Prompt</label>
+                    <textarea id="gg_promptGuidedResponse" name="promptGuidedResponse" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptGuidedResponse" style="margin-top:4px;">Default</button>
+                </div>
+                <div class="setting_item">
+                    <label for="gg_promptGuidedSwipe" style="margin-left: 8px; min-width:150px; display:block;">Guided Swipe Prompt</label>
+                    <textarea id="gg_promptGuidedSwipe" name="promptGuidedSwipe" class="gg-setting-input text_pole" rows="3" style="width:100%; margin-left:8px; min-width:200px;"></textarea>
+                    <button type="button" class="gg-default-button" data-target="promptGuidedSwipe" style="margin-top:4px;">Default</button>
+                </div>
             </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -203,6 +203,11 @@
     cursor: pointer;
 }
 
+/* Ensure preset input and buttons wrap on narrow widths */
+.GuidedGenerations-Extension-settingslist .setting_item > div {
+    flex-wrap: wrap;
+}
+
 /* Edit Intros Popup Styles */
 .gg-popup {
     display: none;


### PR DESCRIPTION
I'm excited to ship a major update to **Guided Generations**—full support for per‑tool presets, models, and prompt‑template overrides, all configurable in‑app.

## 🚀 What’s New

### 1. Revamped Settings Panel
- **Prompt Overrides**
  - New textareas for every guide/tool:
    - Clothes, State, Thinking, Situational, Rules, Custom
    - Corrections, Spellchecker, Edit Intros
    - Impersonation (1st/2nd/3rd Person)
    - Guided Response & Guided Swipe
  - Use `{{input}}` as your placeholder; click “Default” to restore, or “✖” to clear.
- **Presets by Tool**
  - Assign any SillyTavern preset (and its API/model) per guide/tool.
  - On execution, the extension auto‑switches to your chosen preset, runs the action, then restores your previous preset—enabling different LLMs/models per feature.
- **Injection Role**
  - Choose whether instructions inject as `system`, `assistant`, or `user`.
- **Visibility & Auto‑Trigger**
  - Toggle which buttons appear (Impersonation, Guided Response/Swipe, Persistent Guides).
  - Enable/disable auto‑trigger for Thinking, State, and Clothes guides.

### 2. Tools & Guides Now Fully Customizable
- **Corrections & Spellchecker**
  - Pull from your custom override instead of hard‑coded prompts.
- **Edit Intros, Simple Send & Input Recovery**
  - Seamless integration with presets and overrides.
- **Impersonation (👤/👥/🗣️)**
  - Each perspective uses its own prompt template.
- **Guided Response (🐕) & Guided Swipe (👈)**
  - Respect user‑defined templates for injection and regeneration.
- **Persistent Guides (📖)**
  - All “Clothes”, “State”, “Thinking”, “Situational”, and “Rules” generators now use your overrides and can run under specific presets.

### 3. Under the Hood
- Refactored `runGuideScript` to accept `genAs` & `genCommandSuffix` for maximum flexibility.
- Centralized settings load/update in `index.js`.
- `settings.html` + `settingsPanel.js` now auto‑injects clear/default buttons and enforces min widths.
- Version bumped to **1.1.6** in `manifest.json`.

---
