### PR TITLE
[1.3.3] Swipe Hotfix and Default Button Hotfix

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,3 +1,2 @@
 - the files in the Folder References are just that. It is the source code of SillyTavern for which we are building an extension. And it is the original Guided Generations Quickreply set wich we try to emulate.
-- Before each commit to git, increment the patch version (y in z.x.y) in manifest.json; Only Increments If we changed anything on any other file then the manifest.json. Never Increment for the manifest.json itself.
 - in addition to analizing and editing files always give a short explanation of what you are doing before each step.

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ export const extensionName = "GuidedGenerations-Extension"; // Use the simple na
 let isSending = false; 
 // Removed storedInput as recovery now uses stscript global vars
 
-const defaultSettings = {
+export const defaultSettings = {
     autoTriggerClothes: false, // Default off
     autoTriggerState: false,   // Default off
     autoTriggerThinking: false, // Default off

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,6 @@
     "css": "style.css",
     "author": "Samuel Eiras",
     "description": "Adds various buttons to guide AI generation within SillyTavern, enhancing control over character portrayal, actions, and narrative flow.",
-    "version": "1.3.2",
+    "version": "1.3.7",
     "manifest_version": 3
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,6 @@
     "css": "style.css",
     "author": "Samuel Eiras",
     "description": "Adds various buttons to guide AI generation within SillyTavern, enhancing control over character portrayal, actions, and narrative flow.",
-    "version": "1.3.7",
+    "version": "1.3.3",
     "manifest_version": 3
 }

--- a/scripts/guidedSwipe.js
+++ b/scripts/guidedSwipe.js
@@ -224,7 +224,7 @@ const guidedSwipe = async () => {
             // Use the currentInjectionRole retrieved above
             const stscriptCommand = 
                 `// Guided Swipe logic|
-                /inject id=instruct position=before_char ephemeral=true depth=0 role=${injectionRole} ${filledPrompt}|
+                /inject id=instruct position=chat ephemeral=true depth=0 role=${injectionRole} ${filledPrompt}|
                 `;
             
             // Get context and execute directly
@@ -271,7 +271,7 @@ const guidedSwipe = async () => {
             // Clean up potentially failed injection attempt and restore input before returning
             jQueryRef("#send_textarea").val(originalInput).trigger('input');
             // Use the correct key for deletion as well
-            await executeSTScriptCommand('/inject id=instruct delete');
+            await executeSTScriptCommand('/flushinject id=instruct');
             return; // Stop execution
         }
 
@@ -307,7 +307,7 @@ const guidedSwipe = async () => {
         }
         // Clean up injection using the correct key
         console.log('[GuidedGenerations][Swipe] Cleaning up injection (finally block)');
-        await executeSTScriptCommand('/inject id=instruct delete'); // Already using 'instruct' ID here, which seems correct
+        await executeSTScriptCommand('/flushinject id=instruct'); // Already using 'instruct' ID here, which seems correct
     }
 };
 

--- a/scripts/guidedSwipe.js
+++ b/scripts/guidedSwipe.js
@@ -36,9 +36,9 @@ async function executeSTScriptCommand(command) {
 }
 
 /**
- * Finds the last swipe for the last message, swipes to it, and triggers one more swipe (generation).
- * Handles button finding, retries, and potential forcing.
- * Uses local helper functions and correct imports.
+ * Finds the last swipe for the last message, navigates directly to it,
+ * and triggers one more swipe (generation) by clicking the button once.
+ * Uses direct manipulation for navigation and waits for generation end event.
  * @returns {Promise<boolean>} True if successful, false otherwise.
  */
 async function generateNewSwipe() {
@@ -49,102 +49,147 @@ async function generateNewSwipe() {
         return false;
     }
 
+    // Ensure necessary functions/objects are available from SillyTavern's scope
+    let context = getContext();
+    const expectedContextProps = ['chat', 'messageFormatting', 'eventSource', 'event_types'];
+    const missingProps = expectedContextProps.filter(prop => !(prop in context) || context[prop] === undefined);
+
+    if (missingProps.length > 0) {
+        const errorMessage = `Could not get necessary functions/objects from context. Missing: ${missingProps.join(', ')}`;
+        console.error(`[GuidedGenerations][Swipe] ${errorMessage}`);
+        alert(`Guided Swipe Error: ${errorMessage}`);
+        return false;
+    }
+
+    // Destructure necessary functions and variables from the context *after* validation
+    const { chat, messageFormatting, eventSource, event_types } = context;
+
     try {
-        // --- Get Initial Swipe State --- (Uses imported getContext)
-        let context = getContext();
-        if (!context || !context.chat || context.chat.length === 0) {
-            console.error("[GuidedGenerations][Swipe] Could not get initial chat context for swiping.");
+        // --- 1. Navigate to Last Existing Swipe (Directly) ---
+        context = getContext(); // Get fresh context again before manipulation
+        if (!context || context.chat.length === 0) {
+            console.error("[GuidedGenerations][Swipe] Could not get chat context for swiping.");
             alert("Guided Swipe Error: Cannot access chat context.");
             return false;
         }
         let lastMessageIndex = context.chat.length - 1;
         let messageData = context.chat[lastMessageIndex];
-        if (!messageData || typeof messageData.swipe_id === 'undefined' || !Array.isArray(messageData.swipes)) {
-            console.error("[GuidedGenerations][Swipe] Invalid initial message data for swiping.", messageData);
-            alert("Guided Swipe Error: Cannot read initial swipe data.");
-            return false;
-        }
-        let initialSwipeId = messageData.swipe_id;
-        let initialTotalSwipes = messageData.swipes.length;
+        const mesDom = document.querySelector(`#chat .mes[mesid="${lastMessageIndex}"]`);
 
-        // --- 2. Swipe to Last Existing Swipe --- (Uses local delay)
-        const targetSwipeIndex = Math.max(0, initialTotalSwipes - 1);
-        let clicksToReachLast = Math.max(0, targetSwipeIndex - initialSwipeId);
+        // Check if there are swipes and if navigation is needed
+        if (messageData && Array.isArray(messageData.swipes) && messageData.swipes.length > 1) {
+            const targetSwipeIndex = messageData.swipes.length - 1;
+            if (messageData.swipe_id !== targetSwipeIndex) {
+                console.log(`[GuidedGenerations][Swipe] Navigating directly from swipe ${messageData.swipe_id} to last swipe ${targetSwipeIndex}.`);
+                messageData.swipe_id = targetSwipeIndex;
+                messageData.mes = messageData.swipes[targetSwipeIndex];
+                // Optional: Update extra fields if needed, similar to swipes-go
+                // messageData.extra = structuredClone(messageData.swipe_info?.[targetSwipeIndex]?.extra);
+                // ... other fields
+
+                if (mesDom) {
+                    // Update message text in DOM
+                    const mesTextElement = mesDom.querySelector('.mes_text');
+                    if (mesTextElement) {
+                        mesTextElement.innerHTML = messageFormatting(
+                            messageData.mes, messageData.name, messageData.is_system, messageData.is_user, lastMessageIndex
+                        );
+                    }
+                    // Update swipe counter in DOM
+                    [...mesDom.querySelectorAll('.swipes-counter')].forEach(it => it.textContent = `${messageData.swipe_id + 1}/${messageData.swipes.length}`);
+                } else {
+                    console.warn(`[GuidedGenerations][Swipe] Could not find DOM element for message ${lastMessageIndex} to update UI during direct navigation.`);
+                }
+
+                // Save chat and notify - Removed saveChatConditional() as it's not available
+                eventSource.emit(event_types.MESSAGE_SWIPED, lastMessageIndex);
+                // Update button visibility - Removed showSwipeButtons() as it's not available
+                // showSwipeButtons();
+                // Use standard setTimeout for delay as context.delay is missing
+                await new Promise(resolve => setTimeout(resolve, 150)); // Delay for UI updates/event propagation
+            } else {
+                console.log("[GuidedGenerations][Swipe] Already on the last existing swipe.");
+            }
+        } else {
+            console.log("[GuidedGenerations][Swipe] No existing swipes or only one swipe found. Proceeding to generate first/next swipe.");
+        }
+
+        // --- 2. Trigger the *New* Swipe Generation (Click Button Once) ---
         const selector1 = '#chat .mes:last-child .swipe_right:not(.stus--btn)';
         const selector2 = '#chat .mes:last-child .mes_img_swipe_right';
         let $button = jQueryRef(selector1);
         if ($button.length === 0) $button = jQueryRef(selector2);
+
         if ($button.length === 0) {
-            console.error(`[GuidedGenerations][Swipe] Could not find swipe button.`);
-            alert("Guided Swipe Error: Could not find the swipe button.");
+            console.error(`[GuidedGenerations][Swipe] Could not find the swipe right button to trigger generation.`);
+            alert("Guided Swipe Error: Could not find the swipe button to generate.");
             return false;
         }
-        if (clicksToReachLast > 0) {
-            console.log(`[GuidedGenerations][Swipe] Performing ${clicksToReachLast} clicks to reach the last swipe...`);
-            for (let i = 0; i < clicksToReachLast; i++) {
-                $button.first().trigger('click');
-                await delay(50); // Use local delay
-            }
-            await delay(150); // Use local delay
-        } else {
-            console.log("[GuidedGenerations][Swipe] Already at or beyond the target swipe index. No initial swiping needed.");
-        }
 
-        // --- 3. Verify & Retry --- (Uses imported getContext and local delay)
-        let verificationAttempts = 0;
-        const MAX_VERIFICATION_ATTEMPTS = 3;
-        let finalSwipeIndex = -1;
-        let finalTotalSwipes = -1;
-        while (verificationAttempts < MAX_VERIFICATION_ATTEMPTS) {
-            verificationAttempts++;
-            context = getContext(); // Get fresh context
-            lastMessageIndex = context.chat.length - 1;
-            messageData = context.chat[lastMessageIndex];
-            if (!messageData || typeof messageData.swipe_id === 'undefined' || !Array.isArray(messageData.swipes)) {
-                console.error(`[GuidedGenerations][Swipe] Verification attempt ${verificationAttempts}: Invalid message data. Aborting.`);
-                alert(`Guided Swipe Error: Cannot read swipe data during verification attempt ${verificationAttempts}.`);
-                return false;
-            }
-            finalSwipeIndex = messageData.swipe_id;
-            finalTotalSwipes = messageData.swipes.length;
-            const currentTargetIndex = Math.max(0, finalTotalSwipes - 1);
-            if (finalSwipeIndex >= currentTargetIndex) {
-                console.log(`[GuidedGenerations][Swipe] Successfully on the last swipe.`);
-                break;
-            }
-            if (verificationAttempts < MAX_VERIFICATION_ATTEMPTS) {
-                await delay(100); // Use local delay
-            } else {
-                console.warn(`[GuidedGenerations][Swipe] Still not on last swipe after retries. Forcing...`);
-                const forceClicks = Math.max(0, currentTargetIndex - finalSwipeIndex);
-                console.log(`[GuidedGenerations][Swipe] Force clicks needed: ${forceClicks}`);
-                if (forceClicks > 0) {
-                    for (let i = 0; i < forceClicks; i++) {
-                        $button.first().trigger('click');
-                        await delay(50); // Use local delay
-                    }
-                    await delay(150); // Use local delay
-                    // Re-fetch context one last time after forcing
-                    context = getContext();
-                    lastMessageIndex = context.chat.length - 1;
-                    messageData = context.chat[lastMessageIndex];
-                    finalSwipeIndex = messageData ? messageData.swipe_id : -1;
-                    finalTotalSwipes = messageData && messageData.swipes ? messageData.swipes.length : -1;
-                    console.log(`[GuidedGenerations][Swipe] State after force clicks: Swipe ID: ${finalSwipeIndex}, Total Swipes: ${finalTotalSwipes}`);
+        console.log("[GuidedGenerations][Swipe] Clicking button once to trigger new swipe generation...");
+        $button.first().trigger('click'); // THE VITAL CLICK TO START GENERATION
+
+        // --- 3. Wait for Generation to Finish ---
+        const generationPromise = new Promise((resolve, reject) => {
+            let resolved = false;
+            const timeoutDuration = 120000; // 120 seconds timeout
+            let timeoutId = null;
+
+            const cleanup = () => {
+                clearTimeout(timeoutId);
+                eventSource.removeListener(event_types.GENERATION_ENDED, successListener);
+                // TODO: Consider removing potential error listeners here too if added
+            };
+
+            const successListener = () => {
+                if (!resolved) {
+                    resolved = true;
+                    cleanup();
+                    console.log("[GuidedGenerations][Swipe] Generation ended signal received.");
+                    resolve(true);
                 }
-            }
-        }
+            };
 
-        // --- 4. Final Click to Generate --- (Uses local delay)
-        console.log("[GuidedGenerations][Swipe] Performing final click to trigger generation...");
-        $button.first().trigger('click');
-        await delay(100); // Use local delay
-        console.log("[GuidedGenerations][Swipe] New swipe generated successfully.");
+            // Add the success listener
+            eventSource.once(event_types.GENERATION_ENDED, successListener);
+
+            // Set the timeout
+            timeoutId = setTimeout(() => {
+                if (!resolved) {
+                    // Don't set resolved = true here, let the listener handle success if it comes later
+                    cleanup(); // Remove listener even on timeout
+                    console.error(`[GuidedGenerations][Swipe] Swipe generation timed out after ${timeoutDuration / 1000} seconds.`);
+                    // Reject the promise on timeout
+                    reject(new Error(`Swipe generation timed out after ${timeoutDuration / 1000} seconds.`));
+                }
+            }, timeoutDuration);
+
+            // TODO: Add an error listener if SillyTavern provides one
+            // const errorListener = (errorData) => { if (!resolved) { resolved = true; cleanup(); reject(new Error(...)); }};
+            // eventSource.once(event_types.GENERATION_FAILED, errorListener);
+        });
+
+        // Await the generation promise (will throw on timeout/error)
+        await generationPromise;
+        // Use standard setTimeout for delay as context.delay is missing
+        await new Promise(resolve => setTimeout(resolve, 200)); // Small delay after generation finishes
+
+        // Re-check context to confirm swipe count increased (optional but good practice)
+        context = getContext(); // Get latest context
+        const finalMessageData = context.chat[context.chat.length - 1];
+        const finalSwipeCount = finalMessageData?.swipes?.length ?? 0;
+        console.log(`[GuidedGenerations][Swipe] Final swipe count after generation: ${finalSwipeCount}`);
+
         return true; // Indicate success
 
     } catch (error) {
-        console.error("[GuidedGenerations][Swipe] Error during generateNewSwipe execution:", error);
-        alert(`Guided Swipe Error: ${error.message}`);
+        console.error("[GuidedGenerations][Swipe] Error during swipe generation process:", error);
+        // Format error for alert, preventing duplicate prefixes if already formatted
+        const errorMessage = String(error.message || error).startsWith('Guided Swipe Error:')
+            ? String(error.message || error)
+            : `Guided Swipe Error: ${error.message || error}`;
+        // Ensure alert is shown even if error is just a string
+        alert(errorMessage || "Guided Swipe Error: An unknown error occurred.");
         return false; // Indicate failure
     }
 }
@@ -198,30 +243,45 @@ const guidedSwipe = async () => {
             console.log("[GuidedGenerations][Swipe] No input detected, skipping injection.");
         }
         
-        // --- Wait for injection to be registered before swiping ---
-        if (typeof SillyTavern !== 'undefined' && typeof SillyTavern.getContext === 'function') {
-            const injectionKey = 'script_inject_gg_instruct';
-            const maxAttempts = 5;
-            let attempt = 0;
-            while (attempt < maxAttempts) {
-                const ctx = SillyTavern.getContext();
-                if (ctx.extensionPrompts && ctx.extensionPrompts[injectionKey]) {
-                    console.log('[GuidedGenerations][Swipe] Injection found:', injectionKey);
-                    break;
-                }
-                await delay(200);
-                attempt++;
+        // Wait for the injection to appear in context (with retries and delay)
+        let injectionFound = false;
+        const maxAttempts = 5; // Keep the number of attempts
+        const checkDelay = 150; // Milliseconds to wait between checks
+
+        for (let i = 0; i < maxAttempts; i++) {
+            const currentContext = SillyTavern.getContext(); // Get fresh context each time
+            // Check if the key exists in the extensionPrompts OBJECT - Use the correct key!
+            if (currentContext.extensionPrompts && 'script_inject_instruct' in currentContext.extensionPrompts) {
+                console.log(`[GuidedGenerations][Swipe] Injection found after attempt ${i + 1}.`);
+                injectionFound = true;
+                break; // Exit loop once found
             }
-            if (attempt === maxAttempts) {
-                console.warn('[GuidedGenerations][Swipe] Injection not found after waiting:', injectionKey);
+            // If not found, wait before the next check (unless it's the last attempt)
+            if (i < maxAttempts - 1) {
+                console.log(`[GuidedGenerations][Swipe] Injection check ${i + 1} failed, waiting ${checkDelay}ms...`);
+                await new Promise(resolve => setTimeout(resolve, checkDelay));
             }
         }
-        
-        // --- 2. Generate New Swipe using the extracted function ---
+
+        // If injection was never found after all attempts
+        if (!injectionFound) {
+            const errorMsg = "[GuidedGenerations][Swipe] Critical Error: Guided instruction injection ('script_inject_instruct') failed to appear in context after multiple checks.";
+            console.error(errorMsg);
+            alert("Guided Swipe Error: Could not verify instruction injection ('script_inject_instruct'). Aborting swipe generation.");
+            // Clean up potentially failed injection attempt and restore input before returning
+            jQueryRef("#send_textarea").val(originalInput).trigger('input');
+            // Use the correct key for deletion as well
+            await executeSTScriptCommand('/inject id=instruct delete');
+            return; // Stop execution
+        }
+
+        // --- 2. Generate the new swipe --- (This now only runs if injection was found)
+        console.log('[GuidedGenerations][Swipe] Instruction injection confirmed. Proceeding to generate new swipe...');
         const swipeSuccess = await generateNewSwipe();
 
         if (swipeSuccess) {
             console.log("[GuidedGenerations][Swipe] Guided Swipe finished successfully.");
+            await new Promise(resolve => setTimeout(resolve, 3000)); 
         } else {
             console.error("[GuidedGenerations][Swipe] Guided Swipe failed during swipe generation step.");
             // Error likely already alerted within generateNewSwipe
@@ -245,6 +305,9 @@ const guidedSwipe = async () => {
             // This case should ideally not happen if the initial check passed
             console.warn("[GuidedGenerations][Swipe] Textarea was not available for restoration in finally block.");
         }
+        // Clean up injection using the correct key
+        console.log('[GuidedGenerations][Swipe] Cleaning up injection (finally block)');
+        await executeSTScriptCommand('/inject id=instruct delete'); // Already using 'instruct' ID here, which seems correct
     }
 };
 

--- a/scripts/settingsPanel.js
+++ b/scripts/settingsPanel.js
@@ -1,6 +1,6 @@
 // scripts/settingsPanel.js
 
-import { extensionName, loadSettings, updateSettingsUI, addSettingsEventListeners } from '../index.js';
+import { extensionName, loadSettings, updateSettingsUI, addSettingsEventListeners, defaultSettings } from '../index.js';
 import { renderExtensionTemplateAsync } from '../../../../extensions.js';
 
 /**
@@ -78,6 +78,22 @@ export async function loadSettingsPanel() {
                         if (input) {
                             input.value = '';
                             input.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                    });
+                });
+
+                // Setup default buttons with native event handlers
+                const defaultButtons = container.querySelectorAll('.gg-default-button');
+                defaultButtons.forEach(btn => {
+                    btn.addEventListener('click', () => {
+                        const key = btn.getAttribute('data-target'); // e.g., 'promptGuidedSwipe'
+                        const input = document.getElementById(`gg_${key}`); // e.g., '#gg_promptGuidedSwipe'
+                        if (input && defaultSettings.hasOwnProperty(key)) {
+                            input.value = defaultSettings[key];
+                            // Trigger change event to ensure SillyTavern recognizes the update
+                            input.dispatchEvent(new Event('change', { bubbles: true })); 
+                        } else {
+                            console.warn(`[${extensionName}] Could not find input for gg_${key} or default setting for ${key}`);
                         }
                     });
                 });

--- a/scripts/tools/editIntrosPopup.js
+++ b/scripts/tools/editIntrosPopup.js
@@ -37,7 +37,14 @@ import { getContext, extension_settings } from '../../../../../extensions.js';
 // Class to handle the popup functionality
 export class EditIntrosPopup {
     constructor() {
-        this.selectedOption = null;
+        // Initialize state for multiple selections
+        this.selectedOptions = { 
+            perspective: null, 
+            tense: null, 
+            style: null, 
+            gender: null 
+        };
+        this.isCustomSelected = false; // Track if custom option is active
         this.popupElement = null;
         this.initialized = false;
         this.lastCustomCommand = sessionStorage.getItem('gg_lastCustomCommand') || ''; // Load last command
@@ -48,7 +55,18 @@ export class EditIntrosPopup {
      */
     async init() {
         if (this.initialized) return;
-        
+
+        // Helper function to generate option HTML (to reduce repetition)
+        function generateOptionHtml(category, optionKey, title) {
+            return `<div class="gg-option" data-category="${category}" data-option="${optionKey}">
+                        <span class="gg-option-title">${title}</span>
+                    </div>`;
+        }
+
+        function generateSubOptionHtml(category, value, title) {
+            return `<div class="gg-suboption" data-category="${category}" data-value="${value}">${title}</div>`;
+        }
+
         // Create popup container if it doesn't exist
         if (!document.getElementById('editIntrosPopup')) {
             // Create the popup container
@@ -60,79 +78,70 @@ export class EditIntrosPopup {
                             <span class="gg-popup-close">&times;</span>
                         </div>
                         <div class="gg-popup-body">
+                            <!-- Perspective Section -->
                             <div class="gg-popup-section">
                                 <h3>Perspective</h3>
                                 <div class="gg-option-group">
-                                    <div class="gg-option" data-option="first-person">
+                                    <div class="gg-option" data-category="perspective" data-option="first-person"> <!-- Grouping Option -->
                                         <span class="gg-option-title">First Person</span>
                                         <div class="gg-suboptions">
-                                            <div class="gg-suboption" data-value="first-person-standard">I/me (standard 1st person)</div>
-                                            <div class="gg-suboption" data-value="first-person-by-name">{{user}} by name</div>
-                                            <div class="gg-suboption" data-value="first-person-as-you">{{user}} as you</div>
-                                            <div class="gg-suboption" data-value="first-person-he-him">{{user}} as he/him</div>
-                                            <div class="gg-suboption" data-value="first-person-she-her">{{user}} as she/her</div>
-                                            <div class="gg-suboption" data-value="first-person-they-them">{{user}} as they/them</div>
+                                            ${generateSubOptionHtml('perspective', 'first-person-standard', 'I/me (standard 1st person)')}
+                                            ${generateSubOptionHtml('perspective', 'first-person-by-name', '{{user}} by name')}
+                                            ${generateSubOptionHtml('perspective', 'first-person-as-you', '{{user}} as you')}
+                                            ${generateSubOptionHtml('perspective', 'first-person-he-him', '{{user}} as he/him')}
+                                            ${generateSubOptionHtml('perspective', 'first-person-she-her', '{{user}} as she/her')}
+                                            ${generateSubOptionHtml('perspective', 'first-person-they-them', '{{user}} as they/them')}
                                         </div>
                                     </div>
-                                    <div class="gg-option" data-option="second-person">
+                                    <div class="gg-option" data-category="perspective" data-option="second-person"> <!-- Grouping Option -->
                                         <span class="gg-option-title">Second Person</span>
                                         <div class="gg-suboptions">
-                                            <div class="gg-suboption" data-value="second-person-as-you">{{user}} as you</div>
+                                            ${generateSubOptionHtml('perspective', 'second-person-as-you', '{{user}} as you')}
                                         </div>
                                     </div>
-                                    <div class="gg-option" data-option="third-person">
+                                    <div class="gg-option" data-category="perspective" data-option="third-person"> <!-- Grouping Option -->
                                         <span class="gg-option-title">Third Person</span>
                                         <div class="gg-suboptions">
-                                            <div class="gg-suboption" data-value="third-person-by-name">{{user}} by name and pronouns</div>
+                                            ${generateSubOptionHtml('perspective', 'third-person-by-name', '{{user}} by name and pronouns')}
                                         </div>
                                     </div>
                                 </div>
                             </div>
+
+                            <!-- Tense Section -->
                             <div class="gg-popup-section">
                                 <h3>Tense</h3>
                                 <div class="gg-option-group">
-                                    <div class="gg-option" data-option="past-tense">
-                                        <span class="gg-option-title">Past Tense</span>
-                                    </div>
-                                    <div class="gg-option" data-option="present-tense">
-                                        <span class="gg-option-title">Present Tense</span>
-                                    </div>
+                                    ${generateOptionHtml('tense', 'past-tense', 'Past Tense')}
+                                    ${generateOptionHtml('tense', 'present-tense', 'Present Tense')}
                                 </div>
                             </div>
+
+                            <!-- Style Section -->
                             <div class="gg-popup-section">
                                 <h3>Style</h3>
                                 <div class="gg-option-group">
-                                    <div class="gg-option" data-option="novella-style">
-                                        <span class="gg-option-title">Novella Style</span>
-                                    </div>
-                                    <div class="gg-option" data-option="internet-rp-style">
-                                        <span class="gg-option-title">Internet RP Style</span>
-                                    </div>
-                                    <div class="gg-option" data-option="literary-style">
-                                        <span class="gg-option-title">Literary Style</span>
-                                    </div>
-                                    <div class="gg-option" data-option="script-style">
-                                        <span class="gg-option-title">Script Style</span>
-                                    </div>
+                                    ${generateOptionHtml('style', 'novella-style', 'Novella Style')}
+                                    ${generateOptionHtml('style', 'internet-rp-style', 'Internet RP Style')}
+                                    ${generateOptionHtml('style', 'literary-style', 'Literary Style')}
+                                    ${generateOptionHtml('style', 'script-style', 'Script Style')}
                                 </div>
                             </div>
+
+                            <!-- Gender Section -->
                             <div class="gg-popup-section">
-                                <h3>Gender</h3>
+                                <h3>Gender (for {{user}})</h3>
                                 <div class="gg-option-group">
-                                    <div class="gg-option" data-option="he-him">
-                                        <span class="gg-option-title">He/Him</span>
-                                    </div>
-                                    <div class="gg-option" data-option="she-her">
-                                        <span class="gg-option-title">She/Her</span>
-                                    </div>
-                                    <div class="gg-option" data-option="they-them">
-                                        <span class="gg-option-title">They/Them</span>
-                                    </div>
+                                    ${generateOptionHtml('gender', 'he-him', 'He/Him')}
+                                    ${generateOptionHtml('gender', 'she-her', 'She/Her')}
+                                    ${generateOptionHtml('gender', 'they-them', 'They/Them')}
                                 </div>
                             </div>
+
+                            <!-- Custom Command Section -->
                             <div class="gg-popup-section gg-custom-command-section">
-                                <h3>Custom Command</h3>
-                                <div class="gg-option gg-custom-option" data-option="custom">
+                                <h3>Custom</h3>
+                                <div class="gg-option gg-custom-option" data-category="custom" data-option="custom"> <!-- Added category -->
                                     <span class="gg-option-title">Use Custom Instruction Below</span>
                                 </div>
                                 <textarea id="gg-custom-edit-command" placeholder="Enter custom rewrite instruction here...">${this.lastCustomCommand}</textarea>
@@ -140,114 +149,167 @@ export class EditIntrosPopup {
                         </div>
                         <div class="gg-popup-footer">
                             <button id="ggCancelEditIntros" class="gg-button gg-button-secondary">Cancel</button>
-                            <button id="ggApplyEditIntros" class="gg-button gg-button-primary">Apply</button>
+                            <button id="ggMakeNewIntro" class="gg-button gg-button-primary">Make New Intro</button>
+                            <button id="ggApplyEditIntros" class="gg-button gg-button-primary">Edit Intro</button>
                         </div>
                     </div>
                 </div>
             `;
-            
+
             // Append to body
             const popupContainer = document.createElement('div');
             popupContainer.innerHTML = popupHtml;
             document.body.appendChild(popupContainer.firstElementChild);
         }
-        
+
         // Get the popup element reference
         this.popupElement = document.getElementById('editIntrosPopup');
-        
+
         // Setup event listeners
         this.setupEventListeners();
-        
+
         this.initialized = true;
     }
 
     /**
-     * Setup event listeners for the popup
+     * Setup event listeners for the popup elements
      */
     setupEventListeners() {
+        if (!this.popupElement) return;
+
         const closeButton = this.popupElement.querySelector('.gg-popup-close');
         const cancelButton = this.popupElement.querySelector('#ggCancelEditIntros');
         const applyButton = this.popupElement.querySelector('#ggApplyEditIntros');
-        const options = this.popupElement.querySelectorAll('.gg-option:not(.gg-custom-option)');
+        const makeNewIntroButton = this.popupElement.querySelector('#ggMakeNewIntro');
+        const options = this.popupElement.querySelectorAll('.gg-option:not(.gg-custom-option)'); // Exclude custom
         const suboptions = this.popupElement.querySelectorAll('.gg-suboption');
         const customOption = this.popupElement.querySelector('.gg-custom-option');
         const customCommandTextarea = this.popupElement.querySelector('#gg-custom-edit-command');
 
+        // Close/Cancel Actions
         closeButton.addEventListener('click', () => this.close());
         cancelButton.addEventListener('click', () => this.close());
+
+        // Apply/Make New Actions
         applyButton.addEventListener('click', () => this.applyChanges());
+        makeNewIntroButton.addEventListener('click', () => this.makeNewIntro());
+
+        // --- Category Option/Suboption Click Logic ---
+        const handleCategorySelection = (element) => {
+            const category = element.dataset.category;
+            const value = element.dataset.value || element.dataset.option; // Use data-value for suboptions, data-option for options
+            
+            // Deselect other options *within the same category*
+            this.popupElement.querySelectorAll(`[data-category="${category}"]`).forEach(el => {
+                el.classList.remove('selected');
+            });
+
+            // Select the clicked option
+            element.classList.add('selected');
+            // If it's a suboption, also mark its parent option visually (optional, for clarity)
+            if (element.classList.contains('gg-suboption')) {
+                 element.closest('.gg-option')?.classList.add('selected');
+            }
+
+            // Update state
+            this.selectedOptions[category] = value;
+            this.isCustomSelected = false;
+
+            // Deselect custom option visually
+            customOption.classList.remove('selected');
+            console.log('Selected Options:', this.selectedOptions);
+        };
 
         options.forEach(option => {
-            option.addEventListener('click', () => {
-                if (option.querySelector('.gg-suboptions')) {
-                    return;
-                }
-                
-                this.deselectAllPresets();
-                customOption.classList.remove('selected');
-                
-                option.classList.add('selected');
-                this.selectedOption = option.dataset.option;
-            });
+            // Handle clicks on main options that DON'T have suboptions
+            if (!option.querySelector('.gg-suboptions')) {
+                option.addEventListener('click', (event) => {
+                    // Prevent triggering if click was on the suboptions container itself
+                    if (event.target.closest('.gg-suboptions')) return; 
+                    handleCategorySelection(option);
+                 });
+            }
+            // We don't need listeners on parent options with suboptions, only the suboptions themselves
         });
 
         suboptions.forEach(suboption => {
-            suboption.addEventListener('click', (e) => {
-                e.stopPropagation();
-                
-                this.deselectAllPresets();
-                customOption.classList.remove('selected');
-
-                suboption.classList.add('selected');
-                this.selectedOption = suboption.dataset.value;
-                
-                // Optional: Close submenu after selection if desired
-                // setTimeout(() => { suboption.closest('.gg-suboptions').style.display = 'none'; }, 200);
+            suboption.addEventListener('click', () => {
+                handleCategorySelection(suboption);
             });
         });
 
+        // --- Custom Option Click Logic ---
         customOption.addEventListener('click', () => {
-            this.deselectAllPresets();
+            // Deselect all category options
+            this.popupElement.querySelectorAll('.gg-option:not(.gg-custom-option), .gg-suboption').forEach(el => {
+                el.classList.remove('selected');
+            });
+
+            // Reset category selections in state
+            Object.keys(this.selectedOptions).forEach(key => {
+                this.selectedOptions[key] = null;
+            });
+
+            // Select custom option
             customOption.classList.add('selected');
-            this.selectedOption = 'custom';
-        });
-        
-        customCommandTextarea.addEventListener('input', () => {
-            this.lastCustomCommand = customCommandTextarea.value;
-            if (this.lastCustomCommand.trim() !== '') {
-                sessionStorage.setItem('gg_lastCustomCommand', this.lastCustomCommand);
-            } else {
-                sessionStorage.removeItem('gg_lastCustomCommand');
-            }
+            this.isCustomSelected = true;
+            console.log('Custom Selected. Options:', this.selectedOptions);
         });
 
-        this.restoreSelectionState();
+        // --- Custom Textarea Input Logic ---
+        customCommandTextarea.addEventListener('input', () => {
+             // Automatically select 'Custom' if the user types in the textarea
+            if (!this.isCustomSelected) {
+                customOption.click(); // Simulate a click on the custom option
+            }
+        });
     }
 
     deselectAllPresets() {
         this.popupElement.querySelectorAll('.gg-option:not(.gg-custom-option), .gg-suboption').forEach(el => {
             el.classList.remove('selected');
         });
-        if (this.selectedOption !== 'custom') { 
-             this.selectedOption = null;
-        }
+        Object.keys(this.selectedOptions).forEach(key => {
+            this.selectedOptions[key] = null;
+        });
+        this.isCustomSelected = false;
     }
 
     restoreSelectionState() {
         const customOption = this.popupElement.querySelector('.gg-custom-option');
-        if (this.selectedOption) {
-            if (this.selectedOption === 'custom') {
-                customOption.classList.add('selected');
-            } else {
-                const selectedElement = this.popupElement.querySelector(`[data-option="${this.selectedOption}"], [data-value="${this.selectedOption}"]`);
+        if (this.isCustomSelected) {
+            customOption.classList.add('selected');
+        } else {
+            Object.keys(this.selectedOptions).forEach(key => {
+                const selectedElement = this.popupElement.querySelector(`[data-option="${key}"], [data-value="${this.selectedOptions[key]}"]`);
                 if (selectedElement) {
                     selectedElement.classList.add('selected');
                 }
-                customOption.classList.remove('selected'); 
-            }
-        } else {
-             customOption.classList.remove('selected'); 
+            });
+            customOption.classList.remove('selected'); 
         }
+    }
+
+    /**
+     * Resets the selection state both visually and in the internal state object,
+     * but preserves the custom command text.
+     */
+    _resetSelections() {
+        // Reset state variables
+        this.isCustomSelected = false;
+        Object.keys(this.selectedOptions).forEach(key => {
+            this.selectedOptions[key] = null;
+        });
+
+        // Reset visual state
+        this.popupElement.querySelectorAll('.gg-option.selected, .gg-suboption.selected').forEach(el => {
+            el.classList.remove('selected');
+        });
+        // Ensure custom is visually deselected too
+        this.popupElement.querySelector('.gg-custom-option')?.classList.remove('selected');
+        
+        console.log('Selections reset.');
+        // NOTE: We intentionally do NOT clear the custom command textarea here.
     }
 
     /**
@@ -272,7 +334,7 @@ export class EditIntrosPopup {
         if (this.popupElement) {
             this.popupElement.style.display = 'none';
         }
-        this.selectedOption = null;
+        this.deselectAllPresets();
     }
 
     /**
@@ -282,31 +344,39 @@ export class EditIntrosPopup {
         let instruction = '';
         const customCommandTextarea = this.popupElement.querySelector('#gg-custom-edit-command');
 
-        if (this.selectedOption === 'custom') {
+        // --- Build Instruction --- 
+        if (this.isCustomSelected) {
             const customCommand = customCommandTextarea.value.trim();
             if (customCommand === '') {
-                alert('Please enter an instruction in the Custom Command text area.');
-                return; 
+                alert('Custom option is selected, but the instruction text area is empty.');
+                return;
             }
             instruction = customCommand;
             console.log('[GuidedGenerations] Applying custom instruction.');
-            sessionStorage.setItem('gg_lastCustomCommand', customCommand); 
-        } else if (this.selectedOption) {
-            instruction = EDIT_INTROS_OPTIONS[this.selectedOption];
-            if (!instruction) {
-                console.error(`[GuidedGenerations] No instruction found for preset option: ${this.selectedOption}`);
-                alert('Selected preset option is invalid. Please try again.');
-                return; 
-            }
-             console.log(`[GuidedGenerations] Applying preset: ${this.selectedOption}`);
+            // Keep last custom command saving logic if desired
+             sessionStorage.setItem('gg_lastCustomCommand', customCommand); 
         } else {
-            alert('Please select an edit option or choose Custom and enter an instruction.');
-            return; 
+            const selectedInstructions = [];
+            // Combine instructions from selected categories
+            Object.keys(this.selectedOptions).forEach(category => {
+                const selectedKey = this.selectedOptions[category];
+                if (selectedKey && EDIT_INTROS_OPTIONS[selectedKey]) {
+                    selectedInstructions.push(EDIT_INTROS_OPTIONS[selectedKey]);
+                }
+            });
+            
+            if (selectedInstructions.length === 0) {
+                 alert('Please select at least one category option, or choose Custom and enter an instruction.');
+                 return; 
+            }
+            instruction = selectedInstructions.join('. '); // Join instructions with a period and space
+            console.log(`[GuidedGenerations] Applying combined presets: ${instruction}`);
         }
 
         const textareaElement = document.getElementById('send_textarea');
-        const customEdit = textareaElement ? textareaElement.value.trim() : ''; 
+        const customEdit = textareaElement ? textareaElement.value.trim() : '';
 
+        // --- Construct Script (Existing logic, using the new 'instruction') ---
         const scriptPart1 = `
 
             // Editing Intro messages |
@@ -324,7 +394,7 @@ export class EditIntrosPopup {
             /cut 0|
         `;
 
-        // Preset switching logic
+        // --- Preset Switching Logic (Existing logic) ---
         const usePresetSwitching = extension_settings[extensionName]?.useGGSytemPreset ?? true;
         let presetSwitchStart = '';
         let presetSwitchEnd = '';
@@ -351,24 +421,138 @@ export class EditIntrosPopup {
             presetSwitchEnd = `// Preset switching disabled by setting|`;
         }
 
+        // --- Execute Script (Existing logic) ---
         try {
             const context = getContext();
             await context.executeSlashCommandsWithOptions(presetSwitchStart + '\n' + scriptPart1, { showOutput: false });
             const swipeSuccess = await generateNewSwipe();
             if (swipeSuccess) {
+                // Wait a short moment before executing the final part
+                await new Promise(resolve => setTimeout(resolve, 3000)); 
                 await context.executeSlashCommandsWithOptions(scriptPart2 + '\n' + presetSwitchEnd, { showOutput: false });
                 console.log('[GuidedGenerations] Edit Intros script executed successfully.');
             } else {
                 console.error('[GuidedGenerations] Failed to generate new swipe.');
+                 // Still switch back preset on failure?
+                 await context.executeSlashCommandsWithOptions(presetSwitchEnd, { showOutput: false });
             }
         } catch (error) {
             console.error('[GuidedGenerations] Error executing Edit Intros script:', error);
+            // Ensure preset is switched back even on error
+            await context.executeSlashCommandsWithOptions(presetSwitchEnd, { showOutput: false });
         }
-        
+
+        // Reset selections before closing, preserving custom text
+        this._resetSelections();
+
         if (customEdit && textareaElement) {
             textareaElement.value = '';
         }
         
+        this.close();
+    }
+
+    /**
+     * Creates a new intro based on the selected option or custom instruction.
+     */
+    async makeNewIntro() {
+        console.log('Make New Intro button clicked');
+        let instruction = '';
+        const customCommandTextarea = this.popupElement.querySelector('#gg-custom-edit-command');
+
+        // --- Build Instruction (Same logic as applyChanges) --- 
+        if (this.isCustomSelected) {
+            const customCommand = customCommandTextarea.value.trim();
+            if (customCommand === '') {
+                alert('Custom option is selected, but the instruction text area is empty.');
+                return;
+            }
+            instruction = customCommand;
+            console.log('[GuidedGenerations] Making new intro with custom instruction.');
+             sessionStorage.setItem('gg_lastCustomCommand', customCommand); 
+        } else {
+            const selectedInstructions = [];
+            // Combine instructions from selected categories
+            Object.keys(this.selectedOptions).forEach(category => {
+                const selectedKey = this.selectedOptions[category];
+                if (selectedKey && EDIT_INTROS_OPTIONS[selectedKey]) {
+                    selectedInstructions.push(EDIT_INTROS_OPTIONS[selectedKey]);
+                }
+            });
+            
+            if (selectedInstructions.length === 0) {
+                 alert('Please select at least one category option, or choose Custom and enter an instruction.');
+                 return; 
+            }
+            instruction = selectedInstructions.join('. '); // Join instructions with a period and space
+            console.log(`[GuidedGenerations] Making new intro with combined presets: ${instruction}`);
+        }
+
+        // --- Construct Modified Script (Existing logic, using new 'instruction') ---
+        const scriptPart1 = `
+            // Making New Intro message |
+            /sys at=0 Making New Intro message |
+
+            // Set the instruction |
+            /setvar key=inp "${instruction.replace(/"/g, '\\"')}" |
+
+            // Generate the new intro |
+            /inject id=newIntro position=chat ephemeral=true depth=0 [Write the intro based on the following description: {{getvar::inp}}] | `;
+
+        // --- Preset Switching Logic (Existing logic) ---
+        const usePresetSwitching = extension_settings[extensionName]?.useGGSytemPreset ?? true;
+        let presetSwitchStart = '';
+        let presetSwitchEnd = '';
+        if (usePresetSwitching) {
+            presetSwitchStart = `
+// Get the currently active preset|
+/preset|
+/setvar key=currentPreset {{pipe}} |
++
+// If current preset is already GGSytemPrompt, do NOT overwrite oldPreset|
+/if left={{getvar::currentPreset}} rule=neq right="GGSytemPrompt" {: 
+   // Store the current preset in oldPreset|
+   /setvar key=oldPreset {{getvar::currentPreset}} |
+   // Now switch to GGSytemPrompt|
+   /preset GGSytemPrompt |
+:}| 
+`;
+            presetSwitchEnd = `
+// Switch back to the original preset if it was stored|
+/preset {{getvar::oldPreset}} |
+`;
+        } else {
+            presetSwitchStart = `// Preset switching disabled by setting|`;
+            presetSwitchEnd = `// Preset switching disabled by setting|`;
+        }
+
+        // --- Execute Script (Existing logic) ---
+        try {
+            const context = getContext();
+            await context.executeSlashCommandsWithOptions(presetSwitchStart + '\n' + scriptPart1, { showOutput: false });
+            // Wait a short moment *after* initial commands before generating
+            await new Promise(resolve => setTimeout(resolve, 300)); 
+            const swipeSuccess = await generateNewSwipe();
+            if (swipeSuccess) {
+                // Wait a short moment before switching preset back
+                await new Promise(resolve => setTimeout(resolve, 300)); 
+                // Only need to switch preset back
+                await context.executeSlashCommandsWithOptions(presetSwitchEnd, { showOutput: false });
+                console.log('[GuidedGenerations] Make New Intro script executed successfully.');
+            } else {
+                console.error('[GuidedGenerations] Failed to generate new swipe for Make New Intro.');
+                // Still switch back preset on failure?
+                 await context.executeSlashCommandsWithOptions(presetSwitchEnd, { showOutput: false });
+            }
+        } catch (error) {
+            console.error('[GuidedGenerations] Error executing Make New Intro script:', error);
+            // Ensure preset is switched back even on error
+             await context.executeSlashCommandsWithOptions(presetSwitchEnd, { showOutput: false });
+        }
+
+        // Reset selections before closing, preserving custom text
+        this._resetSelections();
+
         this.close();
     }
 

--- a/settings.html
+++ b/settings.html
@@ -170,7 +170,7 @@
                 <hr>
                 <div class="guide-prompt-overrides-section"> <!-- Added wrapper -->
                     <h4>Guide Prompt Overrides</h4>
-                    <small class="setting_item_description">Customize the instructions sent to the AI for specific guides. Use `{{input}}` where you want the original user text to be inserted (if applicable). Use the 'Default' button to restore the original prompt. Check 'Raw' to send the prompt directly as an STScript command instead of injecting it (advanced use).</small>
+                    <small class="setting_item_description">Customize the instructions sent to the AI for specific guides. Use `&#123;&#123;input&#125;&#125;` where you want the original user text to be inserted (if applicable). Use the 'Default' button to restore the original prompt. Check 'Raw' to send the prompt directly as an STScript command instead of injecting it (advanced use).</small>
                     <!-- Textareas for overriding default guide prompts -->
                     <div class="setting_item">
                         <label for="gg_promptClothes" style="margin-left: 8px; min-width:150px; display:block;">Clothes Guide Prompt</label>

--- a/style.css
+++ b/style.css
@@ -211,8 +211,6 @@
 .setting_item {
     padding-left: 10px; /* Indent items slightly */
     padding-right: 10px;
-    padding-top: 5px; /* Add some top padding for separation */
-    padding-bottom: 5px; /* Add some bottom padding */
 }
 
 .guide-prompt-overrides-section .setting_item {
@@ -292,22 +290,22 @@
 }
 
 .gg-popup-section {
-    margin-bottom: 20px;
+    margin-bottom: 15px; /* Space between sections */
 }
 
 .gg-popup-section h3 {
-    margin-top: 0;
-    margin-bottom: 10px;
-    font-size: 1.2em;
-    color: var(--SmartThemeEmColor);
-    border-bottom: 1px solid var(--SmartThemeBorderColor);
-    padding-bottom: 5px;
+    margin-bottom: 8px; /* Space below heading */
+    margin-top: 0; /* Remove default top margin */
+    font-size: 1.1em; /* Slightly larger heading */
+    color: var(--SmartThemeBodyColor); /* Use theme color */
+    border-bottom: 1px solid var(--SmartThemeBorderColor); /* Optional separator */
+    padding-bottom: 4px; /* Space above border */
 }
 
 .gg-option-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
+    display: flex; /* Arrange options in a row */
+    flex-wrap: wrap; /* Allow options to wrap */
+    gap: 8px; /* Space between options */
 }
 
 .gg-option {


### PR DESCRIPTION
Changelog (develop → main)
[1.3.3] – 2025-05-04
Added
Default-button support in settings panel

> “Default” buttons now reset each prompt textarea/input to its original value (via a new defaultSettings export and listeners in scripts/settingsPanel.js).

Changed
Guided swipe injection

>  Switched STScript injection to use the correct key and position (/inject id=instruct position=chat …).
> Added retry loop (5 attempts, 150 ms delay) to wait for instruction injection.
> Enhanced error handling and cleanup paths.

Injection cleanup

> Replaced /inject id=instruct delete with /flushinject id=instruct for reliable removal.

Refactor
Exported defaultSettings from index.js for centralized defaults.
Consolidated preset/clear logic in loadSettingsPanel() and cleaned up UI event wiring.